### PR TITLE
Create Script to Plot Energy vs. Time for "transfer_Li" Simulations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
       # Check whether the files parse as valid Python.
       - id: "check-ast"
       # Check if docstrings come before the code.
-      - id: "check-docstring-first"
+      # - id: "check-docstring-first"
       # Check for debug statements.
       - id: "debug-statements"
       # Verify that test files are named correctly.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -112,6 +112,7 @@
         "posix",
         "postproc",
         "pthresh",
+        "pyedr",
         "pyplot",
         "pyproject",
         "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,11 @@ classifiers = [
 ]
 requires-python = ">=3.7, <3.10"
 dependencies = [
-    "mdtools @ git+https://github.com/andthum/mdtools@main",
     "matplotlib >=3.3, <4.0",
     "MDAnalysis >=2.0, <3.0",
+    "mdtools @ git+https://github.com/andthum/mdtools@main",
     "numpy >=1.15, <2.0",
+    "pyedr >=0.1, <1.0",
     "scipy >=1.0, <2.0",
 ]
 

--- a/scripts/transfer_Li/gmx/energy/plot_energy.py
+++ b/scripts/transfer_Li/gmx/energy/plot_energy.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+
+
+# MIT License
+
+
+r"""
+Plot a selected energy term from a Gromacs .edr file versus time for a
+given 'transfer' simulation.
+
+The energy terms are first averaged over all 'transfer' simulations with
+the same start time.  Afterwards the mean of means and the standard
+deviation of the mean of means is calculated.
+
+To create all relevant plots run
+
+.. code-block:: bash
+
+    for sol in g1 g4 peo63; do
+        for set in re_nvt423_ld pr_nvt423_vr; do
+            for obs in "Potential" "Kinetic En." "Total Energy" "Temperature" "Pressure" "Constr. rmsd" "T-electrodes" "T-electrolyte"; do
+                ~/git/github/lintf2_ether_ana_postproc/.venv/bin/python3 \
+                    ~/git/github/lintf2_ether_ana_postproc/scripts/transfer_Li/gmx/energy/plot_energy.py \
+                        --sol "${sol}" \
+                        --settings "${set}" \
+                        --observable "${obs}" ||
+                        exit
+            done
+        done
+    done
+"""  # noqa: E501, W505
+
+
+# Standard libraries
+import argparse
+import gzip
+import os
+import shutil
+import sys
+import uuid
+from datetime import datetime
+
+# Third-party libraries
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+import pyedr
+from matplotlib import pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def read_edr_gz(
+    fname, observable="Potential", print_obs=False, begin=0, end=-1, every=1
+):
+    """
+    Read a gzipped Gromacs .edr file.
+
+    Parameters
+    ----------
+    fname : str
+        The file name.
+    observable : str, optional
+        The energy term to read from the .edr file.
+    print_obs : bool, optional
+        If ``True``, print all energy terms contained in the .edr file.
+    begin : int, optional
+        First frame to use from the .edr file.  Frame numbering starts
+        at zero.
+    end : int, optional
+        Last frame to use from the .edr file (exclusive).
+    every : int, optional
+        Use every n-th frame from the .edr file.
+
+    Returns
+    -------
+    data : dict
+        A Dictionary that holds the times and the selected observable.
+    units : dict
+        A dictionary containing the time unit and the unit of the
+        selected observable.
+    """
+    # Decompress the gzipped .edr file.
+    timestamp = datetime.now()
+    file_decompressed = (
+        fname[:-7]
+        + "_uuid_"
+        + str(uuid.uuid4())
+        + "_date_"
+        + str(timestamp.strftime("%Y-%m-%d_%H-%M-%S"))
+        + ".edr"
+    )
+    with gzip.open(fname, "rb") as file_in:
+        with open(file_decompressed, "wb") as file_out:
+            shutil.copyfileobj(file_in, file_out)
+
+    # Read decompressed file.
+    data = pyedr.edr_to_dict(file_decompressed, verbose=True)
+    units = pyedr.get_unit_dictionary(file_decompressed)
+
+    # Remove decompressed file.
+    os.remove(file_decompressed)
+
+    if print_obs:
+        print(
+            "The following energy terms are contained in the input file"
+            " '{}':".format(fname)
+        )
+        for key in data.keys():
+            print(key)
+        print("The selected observable is: '{}'".format(observable))
+
+    # Get desired observable.
+    data = {"Time": data["Time"], observable: data[observable]}
+    units = {"Time": units["Time"], observable: units[observable]}
+
+    # Get desired frames.
+    n_frames_tot = len(data["Time"])
+    begin, end, every, n_frames = mdt.check.frame_slicing(
+        start=begin, stop=end, step=every, n_frames_tot=n_frames_tot
+    )
+    for key, value in data.items():
+        data[key] = value[begin:end:every]
+
+    return data, units
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot a selected energy term from a Gromacs .edr file versus time for"
+        " a given 'transfer' simulation."
+    )
+)
+parser.add_argument(
+    "--sol",
+    type=str,
+    required=True,
+    choices=("g1", "g4", "peo63"),
+    help="Solvent name.",
+)
+parser.add_argument(
+    "--settings",
+    type=str,
+    required=True,
+    choices=("re_nvt423_ld", "pr_nvt423_vr"),
+    help="Simulation settings.",
+)
+parser.add_argument(
+    "--observable",
+    type=str,
+    required=False,
+    default="Potential",
+    help=(
+        "The energy term to read from the .edr file.  Default: %(default)s."
+    ),
+)
+parser.add_argument(
+    "--print-obs",
+    required=False,
+    default=False,
+    action="store_true",
+    help="Only print all energy terms contained in the .edr file and exit.",
+)
+parser.add_argument(
+    "--begin",
+    type=int,
+    required=False,
+    default=0,
+    help=(
+        "First frame to use from the .edr file.  Frame numbering starts"
+        " at zero.  Default: %(default)s."
+    ),
+)
+parser.add_argument(
+    "--end",
+    type=int,
+    required=False,
+    default=-1,
+    help=(
+        "Last frame to use from the .edr file (exclusive).  Default:"
+        " %(default)s."
+    ),
+)
+parser.add_argument(
+    "--every",
+    type=int,
+    required=False,
+    default=1,
+    help="Use every n-th frame from the .edr file.  Default: %(default)s.",
+)
+args = parser.parse_args()
+if args.settings == "re_nvt423_ld":
+    time_unit = "ps"
+    time_conv = 1
+elif args.settings == "pr_nvt423_vr":
+    time_unit = "ns"
+    time_conv = 1e-3  # ps -> ns.
+else:
+    raise ValueError("Unknown --settings '{}'".format(args.settings))
+
+system = "lintf2_" + args.sol + "_20-1_gra_q1_sc80"
+analysis = "energy"  # Analysis name.
+tool = "gmx"  # Analysis software.
+outfile = (
+    args.settings
+    + "_"
+    + system
+    + "_"
+    + "transfer_Li_"
+    + analysis
+    + "_"
+    + args.observable.replace(" ", "_").replace(".", "")
+    + ".pdf"
+)
+
+
+print("Creating Simulation instance(s)...")
+sims_dct_sys = leap.transfer.get_sims(system, args.settings)
+if args.print_obs:
+    sims_dct_start = tuple(sims_dct_sys.values())[0]
+    Sims = tuple(sims_dct_start.values())[0]
+    Sim = Sims.sims[0]
+    infile = Sim.settings + "_out_" + Sim.system + ".edr.gz"
+    infile = os.path.join(Sim.path, infile)
+    read_edr_gz(
+        infile,
+        args.observable,
+        args.print_obs,
+        args.begin,
+        args.end,
+        args.every,
+    )
+    print("Done")
+    sys.exit(0)
+
+
+print("Reading data and creating plot(s)...")
+alpha_sims = 0.25
+color_starts = "tab:red"
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    for sys_name, sims_dct_start in sims_dct_sys.items():
+        print("System: {:s}".format(sys_name))
+
+        n_start_times = len(sims_dct_start)
+        cmap = plt.get_cmap()
+        c_vals = np.arange(n_start_times)
+        c_norm = n_start_times - 1
+        c_vals_normed = c_vals / c_norm
+        colors = cmap(c_vals_normed)
+
+        fig, ax = plt.subplots(clear=True)
+        ax.set_prop_cycle(color=colors)
+
+        n_sims_tot = 0
+        for start_ix, (start_time, Sims) in enumerate(sims_dct_start.items()):
+            print("Start time: {:d} ns".format(start_time))
+
+            for sim_ix, Sim in enumerate(Sims.sims):
+                infile = Sim.settings + "_out_" + Sim.system + ".edr.gz"
+                infile = os.path.join(Sim.path, infile)
+                data_dct_sim, units_dct_sim = read_edr_gz(
+                    infile,
+                    args.observable,
+                    args.print_obs,
+                    args.begin,
+                    args.end,
+                    args.every,
+                )
+                time_unit_sim = units_dct_sim["Time"]
+                data_unit_sim = units_dct_sim[args.observable]
+                time_sim = data_dct_sim["Time"] * time_conv
+                data_sim = data_dct_sim[args.observable]
+                if time_unit_sim != "ps":
+                    raise ValueError(
+                        "Expected 'ps' as time unit but got '{}'.  Current"
+                        " simulation: '{}'".format(time_unit_sim, Sim.path)
+                    )
+
+                # Average over all simulations with the same start time.
+                if sim_ix == 0:
+                    time_unit_sims = time_unit_sim
+                    data_unit_sims = data_unit_sim
+                    time_sims = time_sim
+                    data_mom1_sims = data_sim  # First moment (mean).
+                    data_mom2_sims = data_sim**2  # Second moment.
+                    continue
+                if time_unit_sim != time_unit_sims:
+                    raise ValueError(
+                        "The time unit of the current simulation ('{}')"
+                        " differs from that of the previous simulation(s)"
+                        " ('{}').  Current simulation:"
+                        " '{}'".format(time_unit_sim, time_unit_sims, Sim.path)
+                    )
+                if data_unit_sim != data_unit_sims:
+                    raise ValueError(
+                        "The data unit of the current simulation ('{}')"
+                        " differs from that of the previous simulation(s)"
+                        " ('{}').  Current simulation:"
+                        " '{}'".format(data_unit_sim, data_unit_sims, Sim.path)
+                    )
+                if len(time_sim) != len(time_sims):
+                    raise ValueError(
+                        "The number of frames in the current simulation ('{}')"
+                        " differs from that in the previous simulation(s)"
+                        " ('{}').  Current simulation:"
+                        " '{}'".format(len(time_sim), len(time_sims), Sim.path)
+                    )
+                if not np.allclose(time_sim, time_sims, rtol=0):
+                    raise ValueError(
+                        "The times in the current simulation differ from that"
+                        " in the previous simulation(s).  Current simulation:"
+                        " '{}'".format(Sim.path)
+                    )
+                data_mom1_sims += data_sim
+                data_mom2_sims += data_sim**2
+            data_mom1_sims /= Sims.n_sims
+            data_mom2_sims /= Sims.n_sims
+            data_sd_sims = np.sqrt(data_mom2_sims - data_mom1_sims**2)
+            data_sd_sims = data_sd_sims.astype(np.float32)
+
+            if len(time_sims) > 1000:
+                rasterized = True
+            else:
+                rasterized = False
+            ax.fill_between(
+                time_sims,
+                data_mom1_sims - data_sd_sims,
+                data_mom1_sims + data_sd_sims,
+                linewidth=0,
+                alpha=alpha_sims,
+                rasterized=rasterized,
+            )
+            del data_sd_sims
+            ax.plot(
+                time_sims,
+                data_mom1_sims,
+                label=start_time,
+                alpha=alpha_sims,
+                rasterized=rasterized,
+            )
+
+            # Average over all start times.
+            n_sims_tot += Sims.n_sims
+            if start_ix == 0:
+                time_unit_starts = time_unit_sims
+                data_unit_starts = data_unit_sims
+                time_starts = time_sims
+                data_mom1_starts = Sims.n_sims * data_mom1_sims
+                data_mom2_starts = Sims.n_sims * data_mom1_sims**2
+                continue
+            if time_unit_sims != time_unit_starts:
+                raise ValueError(
+                    "The time unit for the current start time ('{}') differs"
+                    " from that for the previous start time(s) ('{}')."
+                    "  Current start time:"
+                    " '{}'".format(
+                        time_unit_sims, time_unit_starts, start_time
+                    )
+                )
+            if data_unit_sims != data_unit_starts:
+                raise ValueError(
+                    "The data unit for the current start time ('{}') differs"
+                    " from that for the previous start time(s) ('{}')."
+                    "  Current start time:"
+                    " '{}'".format(
+                        data_unit_sims, data_unit_starts, start_time
+                    )
+                )
+            if len(time_sims) != len(time_starts):
+                raise ValueError(
+                    "The number of frames for the current start time ('{}')"
+                    " differs from that for the previous start time(s) ('{}')."
+                    "  Current start time:"
+                    " '{}'".format(
+                        len(time_sims), len(time_starts), start_time
+                    )
+                )
+            if not np.allclose(time_sims, time_starts, rtol=0):
+                raise ValueError(
+                    "The times for the current start time differ from that for"
+                    " the previous start time(s).  Current star time:"
+                    " '{}'".format(start_time)
+                )
+            data_mom1_starts += Sims.n_sims * data_mom1_sims
+            data_mom2_starts += Sims.n_sims * data_mom1_sims**2
+        data_mom1_starts /= n_sims_tot
+        data_mom2_starts /= n_sims_tot
+        data_sd_starts = np.sqrt(data_mom2_starts - data_mom1_starts**2)
+        data_sd_starts = data_sd_starts.astype(np.float32)
+        data_mom1_starts = data_mom1_starts.astype(np.float32)
+        data_mom2_starts = data_mom2_starts.astype(np.float32)
+
+        ax.fill_between(
+            time_starts,
+            data_mom1_starts - data_sd_starts,
+            data_mom1_starts + data_sd_starts,
+            linewidth=0,
+            color=color_starts,
+            alpha=leap.plot.ALPHA,
+            rasterized=rasterized,
+        )
+        del data_sd_starts
+        ax.plot(
+            time_starts,
+            data_mom1_starts,
+            label="Mean",
+            color=color_starts,
+            alpha=leap.plot.ALPHA,
+            rasterized=rasterized,
+        )
+        ax.set(
+            xlabel="Time / " + time_unit,
+            ylabel=args.observable + " / " + data_unit_starts,
+            xlim=(time_starts[0], time_starts[-1]),
+        )
+        legend_title = (
+            r"$\sigma_s = \pm %.2f$" % Sims.surfqs[0]
+            + r" $e$/nm$^2$"
+            + "\n"
+            + r"$n_{EO} = %d$, " % Sims.O_per_chain[0]
+            + r"$r = %.2f$" % Sims.Li_O_ratios[0]
+            + "\n"
+            + r"$t_0$ / ns"
+        )
+        legend = ax.legend(
+            title=legend_title,
+            ncol=2,
+            loc="upper right",
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+
+        ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(xlim=(time_starts[1], time_starts[-1]))
+        pdf.savefig()
+        plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/src/lintf2_ether_ana_postproc/__init__.py
+++ b/src/lintf2_ether_ana_postproc/__init__.py
@@ -6,10 +6,10 @@ of LiTFSI-ether mixtures.
 
 
 # Local imports
-from . import clstr, io_handler, misc, plot, simulation
+from . import clstr, io_handler, misc, plot, simulation, transfer
 
 
-__all__ = ["clstr", "io_handler", "misc", "plot", "simulation"]
+__all__ = ["clstr", "io_handler", "misc", "plot", "simulation", "transfer"]
 
 # Project metadata.  Keep in sync with `pyproject.toml`!
 __title__ = "lintf2_ether_ana_postproc"

--- a/src/lintf2_ether_ana_postproc/simulation.py
+++ b/src/lintf2_ether_ana_postproc/simulation.py
@@ -468,7 +468,20 @@ class Simulation:
                 "No such directory: '{}'".format(self.path)
             )
 
-        self.system = os.path.basename(os.path.dirname(self.path))
+        self.system = os.path.basename(self.path)
+        if self.sys_prefix not in self.system:
+            raise ValueError(
+                "Could not infer the system name from the path basename ('{}')"
+                " because the path basename does not contain the common system"
+                " prefix ('{}')".format(self.system, self.sys_prefix)
+            )
+        ix = self.system.find(self.sys_prefix)
+        self.system = self.system[ix:]
+        if len(self.system) == 0:
+            raise ValueError(
+                "Unexpected error: Could not infer the system name from the"
+                " path ('{}')".format(self.path)
+            )
         return self.system
 
     def get_settings(self):

--- a/src/lintf2_ether_ana_postproc/simulation.py
+++ b/src/lintf2_ether_ana_postproc/simulation.py
@@ -52,7 +52,7 @@ class SimPaths:
         :type: dict
         """
 
-        for path in ("bulk", "walls"):
+        for path in ("bulk", "walls", "transfer_Li", "flux_Li"):
             self.PATHS[path] = os.path.normpath(os.path.join(root, path))
         for path in ("q0", "q0.25", "q0.5", "q0.75", "q1"):
             self.PATHS[path] = os.path.normpath(

--- a/src/lintf2_ether_ana_postproc/simulation.py
+++ b/src/lintf2_ether_ana_postproc/simulation.py
@@ -517,9 +517,14 @@ class Simulation:
         self.settings = self.settings.split(self.system)[0]
         if self.system in self.settings:
             raise ValueError(
-                "The last part of `path` ({}) must contain the system name"
-                " ({}) at the end but nowhere"
+                "The path basename ({}) must contain the system name ({}) at"
+                " the end but nowhere"
                 " else".format(os.path.basename(self.path), self.system)
+            )
+        if len(self.settings) < 4:
+            raise ValueError(
+                "Unexpected error: Could not infer the settings string from"
+                " the path ('{}')".format(self.path)
             )
         # Remove preceding number and trailing underscore.
         self.settings = self.settings[3:-1]

--- a/src/lintf2_ether_ana_postproc/simulation.py
+++ b/src/lintf2_ether_ana_postproc/simulation.py
@@ -25,7 +25,8 @@ class SimPaths:
 
     def __init__(self, root=None):
         """
-        Initialize a :class:`~lintf2_ether_ana_postproc.simulation.Path`
+        Initialize a
+        :class:`~lintf2_ether_ana_postproc.simulation.SimPaths`
         instance.
 
         Parameters

--- a/src/lintf2_ether_ana_postproc/simulation.py
+++ b/src/lintf2_ether_ana_postproc/simulation.py
@@ -326,8 +326,8 @@ class Simulation:
 
         self._O_Li_ratio_sys = None
         """
-        Ratio of ether oxygen atoms to lithium ions  as inferred
-        from :attr:`self.system`.
+        Ratio of ether oxygen atoms to lithium ions as inferred from
+        :attr:`self.system`.
 
         See Also
         --------

--- a/src/lintf2_ether_ana_postproc/simulation.py
+++ b/src/lintf2_ether_ana_postproc/simulation.py
@@ -1610,7 +1610,7 @@ class Simulations:
 
         Parameters
         ----------
-        path : str or bytes or os.PathLike
+        paths : str or bytes or os.PathLike
             Relative or absolute paths to the directories containing the
             input and output files of the Gromacs MD simulations you
             want to use.  See
@@ -1796,6 +1796,10 @@ class Simulations:
         """
 
         self.paths = []
+        if len(paths) == 0:
+            raise ValueError(
+                "No paths provided (`paths` = '{}')".format(paths)
+            )
         for path in paths:
             path = os.path.expandvars(os.path.expanduser(path))
             if not os.path.isdir(path):

--- a/src/lintf2_ether_ana_postproc/simulation.py
+++ b/src/lintf2_ether_ana_postproc/simulation.py
@@ -1295,14 +1295,12 @@ class Simulation:
         if self.system is None:
             self.get_system()
 
-        _counts = list(range(2, 6))
-        if self.system.count("_") not in _counts:
+        if self.system.count("_") < 2:
             raise ValueError(
-                "The system name ({}) must follow the pattern"
-                " 'lintf2_solvent_EO-Li-ratio_charge-scaling' or"
-                " 'lintf2_solvent_EO-Li-ratio_electrode_surface-charge"
-                "_charge-scaling' (`_charge-scaling' can be"
-                " omitted)".format(self.system)
+                "The system name ('{}') must start with"
+                " '{}<solvent>_<EO-Li-ratio>'".format(
+                    self.system, self.sys_prefix
+                )
             )
         O_Li_ratio = self.system.split("_")[2]
         n_O, n_Li = O_Li_ratio.split("-")

--- a/src/lintf2_ether_ana_postproc/simulation.py
+++ b/src/lintf2_ether_ana_postproc/simulation.py
@@ -124,6 +124,13 @@ class Simulation:
     change them after initialization.
     """
 
+    sys_prefix = "lintf2_"
+    """
+    Prefix of all system names.
+
+    :type: str
+    """
+
     bulk_sys_suffix = "_sc80"
     """
     Suffix of the system name of all bulk simulations.
@@ -947,22 +954,19 @@ class Simulation:
         if self.system is None:
             self.get_system()
 
-        _counts = list(range(2, 6))
-        if self.system.count("_") not in _counts or not self.system.startswith(
-            "lintf2"
+        if (
+            not self.system.startswith(self.sys_prefix)
+            or self.system.count("_") < 2
         ):
             raise ValueError(
-                "The system name ({}) must follow the pattern"
-                " 'lintf2_solvent_EO-Li-ratio_charge-scaling' or"
-                " 'lintf2_solvent_EO-Li-ratio_electrode_surface-charge"
-                "_charge-scaling' (`_charge-scaling' can be"
-                " omitted)".format(self.system)
+                "The system name ('{}') must start with"
+                " '{}<solvent>_'".format(self.system, self.sys_prefix)
             )
         salt = self.system.split("_")[0]
+        solvent = self.system.split("_")[1]
         self.res_names = {}
         self.res_names["cation"] = salt[:2]
         self.res_names["anion"] = salt[2:]
-        solvent = self.system.split("_")[1]
         self._res_name_solvent = solvent
         if "peo" in solvent:
             # Remove digits from the solvent name, because in my

--- a/src/lintf2_ether_ana_postproc/transfer.py
+++ b/src/lintf2_ether_ana_postproc/transfer.py
@@ -1,0 +1,268 @@
+"""
+Module containing functions specific to the MD simulations in the
+:file:`transfer_Li` directory, i.e. simulations in which a single
+lithium ion has been transferred from the negative electrode surface to
+the positive electrode surface.  In the following, these simulations are
+called 'transfer' simulations.
+"""
+
+
+# Standard libraries
+import glob
+import os
+import re
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+START_PATTERN = "after_[0-9]*ns"
+"""
+Glob pattern matching the names of the directories that contain all
+'transfer' MD simulations that start from the same snapshot/time of the
+underlying equilibrium MD simulation.  Can also be used as regular
+expression.
+
+:type: str
+"""
+
+LI_PATTERN = "Li[0-9]*_transferred"
+"""
+Glob pattern matching the names of the directories that contain the
+simulations for a specific transferred lithium ion.  Can also be used as
+regular expression.
+
+:type: str
+"""
+
+
+def extract_system_from_start_dir(*paths):
+    """
+    Extract the system name from the paths to the directories that
+    contain all 'transfer' MD simulations that start from the same
+    snapshot/time of the underlying equilibrium MD simulation.
+
+    Parameters
+    ----------
+    paths : str or bytes or os.PathLike
+        Relative or absolute paths to the directories that contain all
+        'transfer' MD simulations that start from the same snapshot/time
+        of the underlying equilibrium MD simulation.
+
+    Returns
+    -------
+    systems : list
+        List of system names.  The length of the list is equal to the
+        number of given paths.
+
+    Raises
+    ------
+    FileNotFoundError :
+        If a given path is not an existing directory.
+
+    See Also
+    --------
+    :func:`lintf2_ether_ana_postproc.transfer.get_start_dirs` :
+        Get the paths to the directories that contain all 'transfer' MD
+        simulations that start from the same snapshot/time of the
+        underlying equilibrium MD simulation for a given system.
+    """
+    systems = []
+    for path in paths:
+        path = os.path.expandvars(os.path.expanduser(path))
+        if not os.path.isdir(path):
+            raise FileNotFoundError("No such directory: '{}'".format(path))
+
+        tail = os.path.split(path)[1]
+        if not re.fullmatch(START_PATTERN, tail):
+            raise ValueError(
+                "Invalid start directory for 'transfer' simulations:"
+                " '{}'".format(path)
+            )
+
+        systems.append(os.path.split(os.path.split(path)[0])[1])
+    return systems
+
+
+def extract_start_time_from_start_dir(*paths):
+    """
+    Extract the start times from the names of the directories that
+    contain all 'transfer' MD simulations that start from the same
+    snapshot/time of the underlying equilibrium MD simulation.
+
+    The start times are the times at which the snapshots used
+    to start the 'transfer' simulations were taken from the underlying
+    equilibrium simulation.
+
+    Parameters
+    ----------
+    paths : str or bytes or os.PathLike
+        Relative or absolute paths to the directories that contain all
+        'transfer' MD simulations that start from the same snapshot/time
+        of the underlying equilibrium MD simulation.
+
+    Returns
+    -------
+    start_times : list
+        List of integers representing the times at which the snapshots
+        used to start the 'transfer' simulations were taken from the
+        underlying equilibrium simulation.
+
+    Raises
+    ------
+    FileNotFoundError :
+        If a given path is not an existing directory.
+
+    See Also
+    --------
+    :func:`lintf2_ether_ana_postproc.transfer.get_start_dirs` :
+        Get the paths to the directories that contain all 'transfer' MD
+        simulations that start from the same snapshot/time of the
+        underlying equilibrium MD simulation for a given system.
+    """
+    start_times = []
+    for path in paths:
+        path = os.path.expandvars(os.path.expanduser(path))
+        if not os.path.isdir(path):
+            raise FileNotFoundError("No such directory: '{}'".format(path))
+
+        tail = os.path.split(path)[1]
+        if not re.fullmatch(START_PATTERN, tail):
+            raise ValueError(
+                "Invalid start directory for 'transfer' simulations:"
+                " '{}'".format(path)
+            )
+
+        start_times.append(int("".join(c for c in tail if c.isdigit())))
+    return start_times
+
+
+def get_start_dirs(
+    sys_pat, start_pat=START_PATTERN, sort_by_start=True, sort_by_system=True
+):
+    """
+    Get the paths to the directories that contain all 'transfer' MD
+    simulations that start from the same snapshot/time of the underlying
+    equilibrium MD simulation for a given system.
+
+    Parameters
+    ----------
+    sys_pat : str
+        System name glob pattern.
+    start_pat : str, optional
+        Start directory glob pattern.
+    sort_by_start : bool, optional
+        If ``True``, sort the paths by the start times, i.e. the times
+        at which the snapshots used to start the 'transfer' simulations
+        were taken from the underlying equilibrium simulation.
+    sort_by_system : bool, optional
+        If ``True``, sort the paths by the system name.  Only relevant
+        if `sys_pat` matches more than one system.  The sort by system
+        name is performed after the sort by start time.
+
+    Returns
+    -------
+    start_paths : list
+        List of paths to the directories that contain all 'transfer' MD
+        simulations that start from the same snapshot/time of the
+        underlying equilibrium MD simulation for a given system.
+
+    Raises
+    ------
+    FileNotFoundError :
+        If no directory was found for the given system name.
+    """
+    SimPaths = leap.simulation.SimPaths()
+    sys_pat = os.path.join(SimPaths.PATHS["transfer_Li"], sys_pat)
+    start_pat = os.path.join(sys_pat, start_pat)
+    start_paths = glob.glob(start_pat)
+
+    if len(start_paths) == 0:
+        raise FileNotFoundError(
+            "Could not find any file/directory matching the pattern"
+            " '{}'".format(start_pat)
+        )
+    for path in start_paths:
+        if not os.path.isdir(path):
+            raise FileNotFoundError("No such directory: '{}'".format(path))
+        tail = os.path.split(path)[1]
+        if not re.fullmatch(START_PATTERN, tail):
+            raise ValueError(
+                "Invalid start directory for 'transfer' simulations:"
+                " '{}'".format(path)
+            )
+
+    if sort_by_start:
+        # About the sort key:
+        # `leap.transfer.extract_start_time_from_start_dir` returns a
+        # **list** with one element (the start time of the given start
+        # directory).  Returning a list is not an issue, because the
+        # list only contains one element and Python compares lists
+        # lexicographically.
+        # https://docs.python.org/3/tutorial/datastructures.html#comparing-sequences-and-other-types
+        start_paths = sorted(
+            start_paths, key=leap.transfer.extract_start_time_from_start_dir
+        )
+    if sort_by_system:
+        # `sorted` is guaranteed to be stable, i.e. the relative order
+        # of elements that compare equal is not changed => Previous
+        # sorts are not messed up.
+        start_paths = sorted(
+            start_paths, key=leap.transfer.extract_system_from_start_dir
+        )
+
+    return start_paths
+
+
+def get_sims(sys_pat, set_pat, kwargs_start_dirs=None, kwargs_sims=None):
+    """
+    Create a :class:`~lintf2_ether_ana_postproc.simulation.Simulations`
+    instance from glob patterns.
+
+    Parameters
+    ----------
+    sys_pat : str
+        System name glob pattern.
+    set_pat : str
+        Simulations settings name glob pattern.
+    kwargs_start_dirs : dict, optional
+        Keyword arguments to parse to
+        :func:`lintf2_ether_ana_postproc.transfer.get_start_dirs`.  See
+        there for possible options.
+    kwargs_sims : dict, optional
+        Keyword arguments to parse to
+        :func:`lintf2_ether_ana_postproc.simulation.Simulations`.  See
+        there for possible options.
+
+    Returns
+    -------
+    sims_dct : dict of dict
+        Dictionary containing for each system and each start time the
+        corresponding
+        :class:`~lintf2_ether_ana_postproc.simulation.Simulations`
+        instance.
+    """
+    if kwargs_start_dirs is None:
+        kwargs_start_dirs = {}
+    if kwargs_sims is None:
+        kwargs_sims = {}
+
+    sims_dct = {}
+    start_paths = leap.transfer.get_start_dirs(sys_pat, **kwargs_start_dirs)
+    for start_path in start_paths:
+        sim_pat = "[0-9][0-9]_" + set_pat + "_" + sys_pat + "_" + LI_PATTERN
+        sim_pat = os.path.join(start_path, LI_PATTERN, sim_pat)
+        sim_paths = glob.glob(sim_pat)
+        if len(sim_paths) == 0:
+            raise FileNotFoundError(
+                "Could not find any file/directory matching the pattern"
+                " '{}'".format(sim_pat)
+            )
+        system = leap.transfer.extract_system_from_start_dir(start_path)[0]
+        t0 = leap.transfer.extract_start_time_from_start_dir(start_path)[0]
+        sims_dct.setdefault(system, {})
+        sims_dct[system][t0] = leap.simulation.Simulations(
+            *sim_paths, **kwargs_sims
+        )
+
+    return sims_dct


### PR DESCRIPTION
# Create Script to Plot Energy vs. Time for "transfer_Li" Simulations

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [x] Code refactoring.
* [x] Dependency update.
* [ ] Documentation update.
* [x] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

New Features

* `transfer.py`: Create a new module containing functions specific to the MD simulations in the `transfer_Li` directory, i.e. simulations in which a single lithium ion has been transferred from the negative electrode surface to the positive electrode surface (see also https://github.com/andthum/transfer_Li).
* `plot_energy.py`: Create a script that plots a selected energy term from a Gromacs .edr file versus time for a given 'transfer' simulation.

Code Refactoring

* Class `lintf2_ether_ana_postproc.simulation.Simulation`: Raise a warning instead of an exception when the corresponding bulk simulation cannot be found.
* Class `lintf2_ether_ana_postproc.simulation.Simulation`: Improve the deduction of various system properties from the system name.
* Class `lintf2_ether_ana_postproc.simulation.Simulations`: Raise an exception if no path(s) was provided.

New Dependencies

* Add `pyedr >=0.1, <1.0` to the List of Dependencies.

Maintenance

* `.pre-commit-config.yaml`: Disable `check-docstring-first` from https://github.com/pre-commit/pre-commit-hooks, because it does not support module-level attribute docstrings as defined in PEP257.  See issue https://github.com/pre-commit/pre-commit-hooks/issues/159.

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] The CI workflow is passing.
