### PR TITLE
New Contact Histogram: Total Lithium-Oxygen Coordination

### DIFF
--- a/scripts/bulk_and_walls/mdt/contact_hist/plot_contact_hist_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/contact_hist/plot_contact_hist_chain-length_dependence.py
@@ -54,7 +54,7 @@ parser.add_argument(
     "--cmp",
     type=str,
     required=True,
-    choices=("Li-OE", "Li-OBT"),
+    choices=("Li-OE", "Li-OBT", "Li-O"),
     help=(
         "Compounds for which to plot the coordination numbers.  Default:"
         " %(default)s"
@@ -84,6 +84,10 @@ elif args.cmp == "Li-OBT":
     col_labels = (r"$Li - O_{TFSI}$", r"$Li - TFSI$")
     xlim_hist = [(0, 8), (0, 6)]
     ylim_cn = (0, 0.42)
+elif args.cmp == "Li-O":
+    col_labels = (r"$Li - O_{tot}$", r"$Li - PEO/TFSI$")
+    xlim_hist = [(0, 8), (0, 6)]
+    ylim_cn = (0, 6.5)
 else:
     raise ValueError("Invalid --cmp: {}".format(args.cmp))
 if len(col_labels) != len(cols):
@@ -109,6 +113,11 @@ elif args.cmp == "Li-OBT":
     n_cnt_max = (
         2,  # Maximum number of different O atoms.
         2,  # Maximum number of different TFSI molecules.
+    )
+elif args.cmp == "Li-O":
+    n_cnt_max = (
+        7,  # Maximum number of different O atoms.
+        4,  # Maximum number of different molecules.
     )
 else:
     raise ValueError("Unknown --cmp {}".format(args.cmp))
@@ -238,10 +247,16 @@ with PdfPages(outfile) as pdf:
         ax.set_xscale("log", base=10, subs=np.arange(2, 10))
         ax.set(xlabel=xlabel, ylabel="Probability", xlim=xlim, ylim=ylim_prob)
         if args.cmp == "Li-OE" and col_ix == 0:
+            legend_loc = "best"
+            n_legend_cols = 4
+        if args.cmp == "Li-O" and col_ix == 0:
+            legend_loc = "center right"
             n_legend_cols = 4
         else:
+            legend_loc = "best"
             n_legend_cols = 3
         legend = ax.legend(
+            loc=legend_loc,
             title=legend_title + "\n" + col_labels[col_ix] + " Coord. No.",
             ncol=n_legend_cols,
             **mdtplt.LEGEND_KWARGS_XSMALL,

--- a/scripts/bulk_and_walls/mdt/contact_hist/plot_contact_hist_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/contact_hist/plot_contact_hist_conc_dependence.py
@@ -74,7 +74,7 @@ parser.add_argument(
     "--cmp",
     type=str,
     required=True,
-    choices=("Li-OE", "Li-OBT"),
+    choices=("Li-OE", "Li-OBT", "Li-O"),
     help=(
         "Compounds for which to plot the coordination numbers.  Default:"
         " %(default)s"
@@ -110,6 +110,10 @@ elif args.cmp == "Li-OBT":
     col_labels = (r"$Li - O_{TFSI}$", r"$Li - TFSI$")
     xlim_hist = [(0, 8), (0, 6)]
     ylim_cn = (0, 2.9)
+elif args.cmp == "Li-O":
+    col_labels = (r"$Li - O_{tot}$", r"$Li - PEO/TFSI$")
+    xlim_hist = [(0, 8), (0, 6)]
+    ylim_cn = (0, 6.5)
 else:
     raise ValueError("Invalid --cmp: {}".format(args.cmp))
 if len(col_labels) != len(cols):
@@ -135,6 +139,11 @@ elif args.cmp == "Li-OBT":
     n_cnt_max = (
         6,  # Maximum number of different O atoms.
         5,  # Maximum number of different TFSI molecules.
+    )
+elif args.cmp == "Li-O":
+    n_cnt_max = (
+        7,  # Maximum number of different O atoms.
+        5,  # Maximum number of different molecules.
     )
 else:
     raise ValueError("Unknown --cmp {}".format(args.cmp))


### PR DESCRIPTION
# New Contact Histogram: Total Lithium-Oxygen Coordination

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

Python scripts `plot_contact_hist_chain-length_dependence.py` and `plot_contact_hist_conc_dependence.py`: Add a new choice `"Li-O"` to the command-line option `--cmp` that allows the user to plot the contact histograms for the total lithium-oxygen coordination.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [ ] New/changed code is properly documented.
* [ ] The CI workflow is passing.
