### PR TITLE
Create Scripts to Evaluate the Influence of Different Allowed Intermittency Values on the Bin/Layer Residence Time

### DIFF
--- a/scripts/bulk_and_walls/mdt/discrete-z/get_and_plot_bin_lifetimes_intermittency_dependence.py
+++ b/scripts/bulk_and_walls/mdt/discrete-z/get_and_plot_bin_lifetimes_intermittency_dependence.py
@@ -447,10 +447,11 @@ with PdfPages(outfile) as pdf:
             ax.set_ylim(0, ylim[1])
         leap.plot.bins(ax, bins=bins)
         ax.xaxis.set_major_locator(MaxNLocator(integer=True))
-        legend = ax.legend(
+        legend = fig.legend(
             title=legend_title,
-            loc="best",
             ncol=4,
+            bbox_to_anchor=(0.58, 1.01),
+            loc="upper center",
             **mdtplt.LEGEND_KWARGS_XSMALL,
         )
         legend.get_title().set_multialignment("center")


### PR DESCRIPTION
# Create Scripts to Evaluate the Influence of Different Allowed Intermittency Values on the Bin/Layer Residence Time

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

Create a new Python script `scripts/bulk_and_walls/mdt/discrete-z/get_and_plot_bin_lifetimes_intermittency_dependence.py` that calculates and plots bin residence times / lifetimes for different intermittency values.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] The CI workflow is passing.
