### PR TITLE
Create Scripts to Plot Lifetime Autocorrelation Functions

### DIFF
--- a/scripts/bulk_and_walls/mdt/contact_hist/plot_contact_hist_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/contact_hist/plot_contact_hist_chain-length_dependence.py
@@ -55,10 +55,7 @@ parser.add_argument(
     type=str,
     required=True,
     choices=("Li-OE", "Li-OBT", "Li-O"),
-    help=(
-        "Compounds for which to plot the coordination numbers.  Default:"
-        " %(default)s"
-    ),
+    help="Compounds for which to plot the coordination numbers.",
 )
 args = parser.parse_args()
 

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_chain-length_dependence.py
@@ -91,6 +91,8 @@ if args.cmp in ("Li-OE", "Li-ether"):
 else:
     legend_loc = "upper right"
 
+created_fit = False
+
 cmap = plt.get_cmap()
 c_vals = np.arange(n_infiles)
 c_norm = max(n_infiles - 1, 1)
@@ -140,7 +142,7 @@ with PdfPages(outfile) as pdf:
             color=color,
             alpha=leap.plot.ALPHA,
         )
-        if args.cmp == "Li-OE" and sim_ix == Sims.n_sims - 1:
+        if args.cmp == "Li-OE" and Sim.O_per_chain == 64:
             start, stop = leap.misc.find_nearest(times, [1e0, 2e1])
             times_fit = times[start:stop]
             popt, pcov = curve_fit(
@@ -150,24 +152,26 @@ with PdfPages(outfile) as pdf:
                 p0=(0.1, 2),
             )
             acf_fit = leap.misc.straight_line(np.log(times_fit), *popt)
-            ax.plot(
-                times_fit,
-                acf_fit,
-                color="black",
-                linestyle="dashed",
-                alpha=leap.plot.ALPHA,
-            )
-            ax.text(
-                times_fit[0],
-                acf_fit[0] + 0.01,
-                r"$%.2f \ln(t) + %.2f$" % tuple(popt),
-                rotation=-50,
-                rotation_mode="anchor",
-                transform_rotates_text=False,
-                horizontalalignment="left",
-                verticalalignment="bottom",
-                fontsize="small",
-            )
+            created_fit = True
+    if created_fit:
+        ax.plot(
+            times_fit,
+            acf_fit,
+            color="black",
+            linestyle="dashed",
+            alpha=leap.plot.ALPHA,
+        )
+        ax.text(
+            times_fit[0],
+            acf_fit[0] + 0.01,
+            r"$%.2f \ln(t) + %.2f$" % tuple(popt),
+            rotation=-49,
+            rotation_mode="anchor",
+            transform_rotates_text=False,
+            horizontalalignment="left",
+            verticalalignment="bottom",
+            fontsize="small",
+        )
     ax.set_xscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
     legend = ax.legend(

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_chain-length_dependence.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the lifetime autocorrelation function for two given compounds as
+function of the PEO chain length.
+"""
+
+
+# Standard libraries
+import argparse
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the lifetime autocorrelation function for two given compounds as"
+        " function of the PEO chain length."
+    ),
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=True,
+    choices=("Li-OE", "Li-OBT", "Li-ether", "Li-NTf2"),
+    help="Compounds for which to plot the lifetime autocorrelation function.",
+)
+args = parser.parse_args()
+cmp1, cmp2 = args.cmp.split("-")
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+analysis = "lifetime_autocorr"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+tool = "mdt"  # Analysis software.
+outfile = (  # Output file name.
+    settings + "_lintf2_peoN_20-1_sc80_" + analysis + analysis_suffix + ".pdf"
+)
+
+cols = (  # Columns to read from the input file(s).
+    0,  # Lag times in [ps].
+    1,  # Autocorrelation function.
+)
+
+# Only calculate the lifetime by directly integrating the ACF if the ACF
+# decayed below the given threshold.
+int_thresh = 0.01
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_[gp]*[0-9]*_20-1_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, path_key="bulk", sort_key="O_per_chain"
+)
+
+
+print("Reading data and creating plot(s)...")
+file_suffix = analysis + analysis_suffix + ".txt.gz"
+infiles = leap.simulation.get_ana_files(Sims, analysis, tool, file_suffix)
+n_infiles = len(infiles)
+lifetimes = np.full(n_infiles, np.nan, dtype=np.float32)
+
+xlabel = "Lag Time / ns"
+ylabel = "Autocorrelation Function"
+xlim = (2e-3, 1e3)
+ylim = (0, 1)
+
+legend_title_base = (
+    r"$"
+    + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp1]
+    + "-"
+    + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp2]
+    + r"$"
+    + "\n"
+    + r"$r = %.2f$" % Sims.Li_O_ratios[0]
+)
+legend_title = legend_title_base + "\n" + r"$n_{EO}$"
+n_legend_cols = 1 + n_infiles // (6 + 1)
+if args.cmp in ("Li-OE", "Li-ether"):
+    legend_loc = "lower left"
+else:
+    legend_loc = "upper right"
+
+cmap = plt.get_cmap()
+c_vals = np.arange(n_infiles)
+c_norm = max(n_infiles - 1, 1)
+c_vals_normed = c_vals / c_norm
+colors = cmap(c_vals_normed)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot autocorrelation functions.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        times, acf = np.loadtxt(infiles[sim_ix], usecols=cols, unpack=True)
+        times *= 1e-3  # ps -> ns
+        if np.any(acf <= int_thresh):
+            # Only calculate the lifetime by numerical integration if
+            # the ACF decays below the given threshold.
+            # Only calculate the ACF until its global minimum, a
+            # potential increase of the ACF after the minimum is likely
+            # a finite size artifact and should therefore be discarded.
+            stop = np.nanargmin(acf) + 1
+            lifetimes[sim_ix] = leap.lifetimes.raw_moment_integrate(
+                sf=acf[:stop], x=times[:stop]
+            )
+        if Sim.O_per_chain == 2:
+            color = "tab:red"
+            ax.plot([], [])  # Increment color cycle.
+        elif Sim.O_per_chain == 3:
+            color = "tab:brown"
+            ax.plot([], [])  # Increment color cycle.
+        elif Sim.O_per_chain == 5:
+            color = "tab:orange"
+            ax.plot([], [])  # Increment color cycle.
+        else:
+            color = None
+        if args.cmp == "Li-OE" and Sim.O_per_chain == 4:
+            linestyle = "dashed"
+        elif args.cmp == "Li-OE" and Sim.O_per_chain == 8:
+            linestyle = "dashed"
+        else:
+            linestyle = None
+        ax.plot(
+            times,
+            acf,
+            label=r"%d" % Sim.O_per_chain,
+            linestyle=linestyle,
+            color=color,
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
+    legend = ax.legend(
+        title=legend_title,
+        loc=legend_loc,
+        ncol=n_legend_cols,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot lifetimes.
+    xlabel = r"Ether Oxygens per Chain $n_{EO}$"
+    xlim = (1, 200)
+    fig, ax = plt.subplots(clear=True)
+    ax.plot(Sims.O_per_chain, lifetimes, marker="o")
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel="Relaxation Time / ns", xlim=xlim)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title_base)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_chain-length_dependence.py
@@ -16,9 +16,51 @@ import mdtools as mdt
 import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
 import numpy as np
 from matplotlib.backends.backend_pdf import PdfPages
+from scipy.optimize import curve_fit
 
 # First-party libraries
 import lintf2_ether_ana_postproc as leap
+
+
+def fit_acf(times, acf, start=0, stop=-1):
+    r"""
+    Fit the linear autocorrelation function as function of the
+    logarithmic lag times with a straight line.
+
+    The obtained fit parameters are converted from the parameters of a
+    straight line to the parameters of a power law.
+
+    The fit is done assuming that the exponent of the power law is
+    small (:math:`| \epsilon | \ll 1`).  In this case the following
+    relation holds:
+
+    .. math::
+
+        y = a x^\epsilon
+          = a \exp\left[ \ln\left( x^\epsilon \right) \right]
+          = a \exp\left[ \epsilon \ln(x) \right]
+          \approx a \left[ 1 + \epsilon \ln(x) \right]
+          = a \epsilon \ln(x) + a
+
+    """
+    popt, pcov = curve_fit(
+        f=leap.misc.straight_line,
+        xdata=np.log(times[start:stop]),
+        ydata=acf[start:stop],
+        p0=(1e-3, 2),
+    )
+    perr = np.sqrt(np.diag(pcov))
+    # Convert straight-line parameters to the corresponding power-law
+    # parameters.
+    # Propagation of uncertainty.
+    # Std[A/B] =
+    #   |A/B| * sqrt{(Std[A]/A)^2 + (Std[B]/B)^2 - 2 Cov[A,b]/(AB)}
+    popt_0 = popt[0] / popt[1]
+    perr_0 = np.abs(popt_0)
+    perr_0 *= np.sqrt((perr[0] / popt[0]) ** 2 + (perr[1] / popt[1]) ** 2)
+    perr = np.array([perr_0, perr[1]])
+    popt = np.array([popt_0, popt[1]])
+    return popt, perr
 
 
 # Input parameters.
@@ -139,6 +181,12 @@ with PdfPages(outfile) as pdf:
             color=color,
             alpha=leap.plot.ALPHA,
         )
+        if args.cmp == "Li-OE" and sim_ix == Sims.n_sims - 1:
+            start, stop = leap.misc.find_nearest(times, [1e0, 2e1])
+            popt, perr = fit_acf(times, acf, start=start, stop=stop)
+            times_fit = times[start:stop]
+            fit = leap.misc.power_law(times_fit, *popt)
+            ax.plot(times_fit, fit, color="black", linestyle="dashed")
     ax.set_xscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
     legend = ax.legend(

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_chain-length_dependence.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the lifetime autocorrelation function for a given set of compound
+pairs as function of the PEO chain length.
+"""
+
+
+# Standard libraries
+import argparse
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the lifetime autocorrelation function for a given set of"
+        " compound pairs as function of the PEO chain length."
+    ),
+)
+parser.add_argument(
+    "--cmps",
+    type=str,
+    required=False,
+    default=["Li-OE", "Li-OBT"],
+    nargs="+",
+    help=(
+        "The compound pairs for which to plot the lifetime autocorrelation"
+        " function."
+    ),
+)
+args = parser.parse_args()
+if len(args.cmps) == 0:
+    raise ValueError(
+        "No compound pair specified with --cmps ({})".format(args.cmps)
+    )
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+analysis = "lifetime_autocorr"  # Analysis name.
+tool = "mdt"  # Analysis software.
+outfile = (  # Output file name.
+    settings
+    + "_lintf2_peoN_20-1_sc80_"
+    + analysis
+    + "_combined_"
+    + "_".join(args.cmps)
+    + ".pdf"
+)
+
+cols = (  # Columns to read from the input file(s).
+    0,  # Lag times in [ps].
+    1,  # Autocorrelation function.
+)
+
+# Only calculate the lifetime by directly integrating the ACF if the ACF
+# decayed below the given threshold.
+int_thresh = 0.01
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_[gp]*[0-9]*_20-1_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, path_key="bulk", sort_key="O_per_chain"
+)
+
+
+print("Reading data and creating plot(s)...")
+infiles = [None for cmp in args.cmps]
+for cmp_ix, cmp in enumerate(args.cmps):
+    file_suffix = analysis + "_" + cmp + ".txt.gz"
+    infiles[cmp_ix] = leap.simulation.get_ana_files(
+        Sims, analysis, tool, file_suffix
+    )
+    n_infiles = len(infiles[cmp_ix])
+    if n_infiles != Sims.n_sims:
+        raise ValueError(
+            "The number of input files ({}) for the compound pair {} is not"
+            " equal to the number of simulations"
+            " ({})".format(n_infiles, cmp, Sims.n_sims)
+        )
+lifetimes = np.full((len(args.cmps), Sims.n_sims), np.nan, dtype=np.float32)
+
+xlabel = "Lag Time / ns"
+ylabel = "Autocorrelation Function"
+xlim = (2e-3, 1e3)
+ylim = (0, 1)
+
+legend_title_base = r"$r = %.2f$" % Sims.Li_O_ratios[0]
+legend_title = legend_title_base + "\n" + r"$n_{EO}$"
+n_legend_cols = 1 + Sims.n_sims // (6 + 1)
+
+cmap = plt.get_cmap()
+c_vals = np.arange(Sims.n_sims)
+c_norm = max(Sims.n_sims - 1, 1)
+c_vals_normed = c_vals / c_norm
+colors = cmap(c_vals_normed)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot autocorrelation functions.
+    for cmp_ix, cmp in enumerate(args.cmps):
+        cmp1, cmp2 = cmp.split("-")
+        cmp_label = (
+            r"$"
+            + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp1]
+            + "-"
+            + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp2]
+            + r"$"
+        )
+        legend_title_cmp = cmp_label + "\n" + legend_title
+        if cmp in ("Li-OE", "Li-ether"):
+            legend_loc = "lower left"
+        else:
+            legend_loc = "upper right"
+
+        fig, ax = plt.subplots(clear=True)
+        ax.set_prop_cycle(color=colors)
+        for sim_ix, Sim in enumerate(Sims.sims):
+            times, acf = np.loadtxt(
+                infiles[cmp_ix][sim_ix], usecols=cols, unpack=True
+            )
+            times *= 1e-3  # ps -> ns
+            if np.any(acf <= int_thresh):
+                # Only calculate the lifetime by numerical integration
+                # if the ACF decays below the given threshold.
+                # Only calculate the ACF until its global minimum, a
+                # potential increase of the ACF after the minimum is
+                # likely a finite size artifact and should therefore be
+                # discarded.
+                stop = np.nanargmin(acf) + 1
+                lifetimes[cmp_ix][
+                    sim_ix
+                ] = leap.lifetimes.raw_moment_integrate(
+                    sf=acf[:stop], x=times[:stop]
+                )
+            if Sim.O_per_chain == 2:
+                color = "tab:red"
+                ax.plot([], [])  # Increment color cycle.
+            elif Sim.O_per_chain == 3:
+                color = "tab:brown"
+                ax.plot([], [])  # Increment color cycle.
+            elif Sim.O_per_chain == 5:
+                color = "tab:orange"
+                ax.plot([], [])  # Increment color cycle.
+            else:
+                color = None
+            if cmp == "Li-OE" and Sim.O_per_chain == 4:
+                linestyle = "dashed"
+            elif cmp == "Li-OE" and Sim.O_per_chain == 8:
+                linestyle = "dashed"
+            else:
+                linestyle = None
+            ax.plot(
+                times,
+                acf,
+                label=r"%d" % Sim.O_per_chain,
+                linestyle=linestyle,
+                color=color,
+                alpha=leap.plot.ALPHA,
+            )
+        ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
+        legend = ax.legend(
+            title=legend_title_cmp,
+            loc=legend_loc,
+            ncol=n_legend_cols,
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+    # Plot lifetimes.
+    xlabel = r"Ether Oxygens per Chain $n_{EO}$"
+    xlim = (1, 200)
+    markers = ("^", "v", "s", "D")
+    fig, ax = plt.subplots(clear=True)
+    for cmp_ix, cmp in enumerate(args.cmps):
+        cmp1, cmp2 = cmp.split("-")
+        cmp_label = (
+            r"$"
+            + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp1]
+            + "-"
+            + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp2]
+            + r"$"
+        )
+        ax.plot(
+            Sims.O_per_chain,
+            lifetimes[cmp_ix],
+            label=cmp_label,
+            marker=markers[cmp_ix],
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel="Relaxation Time / ns", xlim=xlim)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title_base)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_conc_dependence.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the lifetime autocorrelation function for a given set of compound
+pairs as function of the salt concentration.
+"""
+
+
+# Standard libraries
+import argparse
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import MultipleLocator
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def equalize_xticks(ax):
+    """
+    Equalize x-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the x
+        ticks.
+    """
+    ax.xaxis.set_major_locator(MultipleLocator(0.1))
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the lifetime autocorrelation function for a given set of"
+        " compound pairs as function of the salt concentration."
+    ),
+)
+parser.add_argument(
+    "--sol",
+    type=str,
+    required=True,
+    choices=("g1", "g4", "peo63"),
+    help="Solvent name.",
+)
+parser.add_argument(
+    "--cmps",
+    type=str,
+    required=False,
+    default=["Li-OE", "Li-OBT"],
+    nargs="+",
+    help=(
+        "The compound pairs for which to plot the lifetime autocorrelation"
+        " function."
+    ),
+)
+args = parser.parse_args()
+if len(args.cmps) == 0:
+    raise ValueError(
+        "No compound pair specified with --cmps ({})".format(args.cmps)
+    )
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+analysis = "lifetime_autocorr"  # Analysis name.
+tool = "mdt"  # Analysis software.
+outfile = (  # Output file name.
+    settings
+    + "_lintf2_"
+    + args.sol
+    + "_r_sc80_"
+    + analysis
+    + "_combined_"
+    + "_".join(args.cmps)
+    + ".pdf"
+)
+
+cols = (  # Columns to read from the input file(s).
+    0,  # Lag times in [ps].
+    1,  # Autocorrelation function.
+)
+
+# Only calculate the lifetime by directly integrating the ACF if the ACF
+# decayed below the given threshold.
+int_thresh = 0.01
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_" + args.sol + "_[0-9]*-[0-9]*_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, path_key="bulk", sort_key="Li_O_ratio"
+)
+
+
+print("Reading data and creating plot(s)...")
+infiles = [None for cmp in args.cmps]
+for cmp_ix, cmp in enumerate(args.cmps):
+    file_suffix = analysis + "_" + cmp + ".txt.gz"
+    infiles[cmp_ix] = leap.simulation.get_ana_files(
+        Sims, analysis, tool, file_suffix
+    )
+    n_infiles = len(infiles[cmp_ix])
+    if n_infiles != Sims.n_sims:
+        raise ValueError(
+            "The number of input files ({}) for the compound pair {} is not"
+            " equal to the number of simulations"
+            " ({})".format(n_infiles, cmp, Sims.n_sims)
+        )
+lifetimes = np.full((len(args.cmps), Sims.n_sims), np.nan, dtype=np.float32)
+
+xlabel = "Lag Time / ns"
+ylabel = "Autocorrelation Function"
+xlim = (2e-3, 1e3)
+ylim = (0, 1)
+
+legend_title_base = r"$n_{EO} = %d$" % Sims.O_per_chain[0]
+legend_title = legend_title_base + "\n" + r"$r$"
+n_legend_cols = 1 + Sims.n_sims // (6 + 1)
+
+cmap = plt.get_cmap()
+c_vals = np.arange(Sims.n_sims)
+c_norm = max(Sims.n_sims - 1, 1)
+c_vals_normed = c_vals / c_norm
+colors = cmap(c_vals_normed)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot autocorrelation functions.
+    for cmp_ix, cmp in enumerate(args.cmps):
+        cmp1, cmp2 = cmp.split("-")
+        cmp_label = (
+            r"$"
+            + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp1]
+            + "-"
+            + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp2]
+            + r"$"
+        )
+        legend_title_cmp = cmp_label + "\n" + legend_title
+        if cmp in ("Li-OE", "Li-ether"):
+            legend_loc = "lower left"
+        else:
+            legend_loc = "upper right"
+
+        fig, ax = plt.subplots(clear=True)
+        ax.set_prop_cycle(color=colors)
+        for sim_ix, Sim in enumerate(Sims.sims):
+            times, acf = np.loadtxt(
+                infiles[cmp_ix][sim_ix], usecols=cols, unpack=True
+            )
+            times *= 1e-3  # ps -> ns
+            if np.any(acf <= int_thresh):
+                # Only calculate the lifetime by numerical integration
+                # if the ACF decays below the given threshold.
+                # Only calculate the ACF until its global minimum, a
+                # potential increase of the ACF after the minimum is
+                # likely a finite size artifact and should therefore be
+                # discarded.
+                stop = np.nanargmin(acf) + 1
+                lifetimes[cmp_ix][
+                    sim_ix
+                ] = leap.lifetimes.raw_moment_integrate(
+                    sf=acf[:stop], x=times[:stop]
+                )
+            if args.sol == "g4" and np.isclose(Sim.Li_O_ratio, 1 / 5, rtol=0):
+                color = "tab:red"
+                ax.plot([], [])  # Increment color cycle.
+            else:
+                color = None
+            ax.plot(
+                times,
+                acf,
+                label=r"$%.4f$" % Sim.Li_O_ratio,
+                color=color,
+                alpha=leap.plot.ALPHA,
+            )
+        ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
+        legend = ax.legend(
+            title=legend_title_cmp,
+            loc=legend_loc,
+            ncol=n_legend_cols,
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+    # Plot lifetimes.
+    xlabel = r"Li-to-EO Ratio $r$"
+    xlim = (0, 0.4 + 0.0125)
+    markers = ("^", "v", "s", "D")
+    fig, ax = plt.subplots(clear=True)
+    for cmp_ix, cmp in enumerate(args.cmps):
+        cmp1, cmp2 = cmp.split("-")
+        cmp_label = (
+            r"$"
+            + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp1]
+            + "-"
+            + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp2]
+            + r"$"
+        )
+        ax.plot(
+            Sims.Li_O_ratios,
+            lifetimes[cmp_ix],
+            label=cmp_label,
+            marker=markers[cmp_ix],
+        )
+    ax.set(xlabel=xlabel, ylabel="Relaxation Time / ns", xlim=xlim)
+    equalize_xticks(ax)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title_base)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_conc_dependence.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the lifetime autocorrelation function for two given compounds as
+function of the salt concentration.
+"""
+
+
+# Standard libraries
+import argparse
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import MultipleLocator
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def equalize_xticks(ax):
+    """
+    Equalize x-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the x
+        ticks.
+    """
+    ax.xaxis.set_major_locator(MultipleLocator(0.1))
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the lifetime autocorrelation function for two given compounds as"
+        " function of the salt concentration."
+    ),
+)
+parser.add_argument(
+    "--sol",
+    type=str,
+    required=True,
+    choices=("g1", "g4", "peo63"),
+    help="Solvent name.",
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=True,
+    choices=("Li-OE", "Li-OBT", "Li-ether", "Li-NTf2"),
+    help="Compounds for which to plot the lifetime autocorrelation function.",
+)
+args = parser.parse_args()
+cmp1, cmp2 = args.cmp.split("-")
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+analysis = "lifetime_autocorr"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+tool = "mdt"  # Analysis software.
+outfile = (  # Output file name.
+    settings
+    + "_lintf2_"
+    + args.sol
+    + "_r_sc80_"
+    + analysis
+    + analysis_suffix
+    + ".pdf"
+)
+
+cols = (  # Columns to read from the input file(s).
+    0,  # Lag times in [ps].
+    1,  # Autocorrelation function.
+)
+
+# Only calculate the lifetime by directly integrating the ACF if the ACF
+# decayed below the given threshold.
+int_thresh = 0.01
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_" + args.sol + "_[0-9]*-[0-9]*_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, path_key="bulk", sort_key="Li_O_ratio"
+)
+
+
+print("Reading data and creating plot(s)...")
+file_suffix = analysis + analysis_suffix + ".txt.gz"
+infiles = leap.simulation.get_ana_files(Sims, analysis, tool, file_suffix)
+n_infiles = len(infiles)
+lifetimes = np.full(n_infiles, np.nan, dtype=np.float32)
+
+xlabel = "Lag Time / ns"
+ylabel = "Autocorrelation Function"
+xlim = (2e-3, 1e3)
+ylim = (0, 1)
+
+legend_title_base = (
+    r"$"
+    + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp1]
+    + "-"
+    + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp2]
+    + r"$"
+    + "\n"
+    + r"$n_{EO} = %d$" % Sims.O_per_chain[0]
+)
+legend_title = legend_title_base + "\n" + r"$r$"
+n_legend_cols = 1 + n_infiles // (6 + 1)
+if args.cmp in ("Li-OE", "Li-ether"):
+    legend_loc = "lower left"
+else:
+    legend_loc = "upper right"
+
+cmap = plt.get_cmap()
+c_vals = np.arange(n_infiles)
+c_norm = max(n_infiles - 1, 1)
+c_vals_normed = c_vals / c_norm
+colors = cmap(c_vals_normed)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot autocorrelation functions.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        times, acf = np.loadtxt(infiles[sim_ix], usecols=cols, unpack=True)
+        times *= 1e-3  # ps -> ns
+        if np.any(acf <= int_thresh):
+            # Only calculate the lifetime by numerical integration if
+            # the ACF decays below the given threshold.
+            # Only calculate the ACF until its global minimum, a
+            # potential increase of the ACF after the minimum is likely
+            # a finite size artifact and should therefore be discarded.
+            stop = np.nanargmin(acf) + 1
+            lifetimes[sim_ix] = leap.lifetimes.raw_moment_integrate(
+                sf=acf[:stop], x=times[:stop]
+            )
+        if args.sol == "g4" and np.isclose(Sim.Li_O_ratio, 1 / 5, rtol=0):
+            color = "tab:red"
+            ax.plot([], [])  # Increment color cycle.
+        else:
+            color = None
+        ax.plot(
+            times,
+            acf,
+            label=r"$%.4f$" % Sim.Li_O_ratio,
+            color=color,
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
+    legend = ax.legend(
+        title=legend_title,
+        loc=legend_loc,
+        ncol=n_legend_cols,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot lifetimes.
+    xlabel = r"Li-to-EO Ratio $r$"
+    xlim = (0, 0.4 + 0.0125)
+    fig, ax = plt.subplots(clear=True)
+    ax.plot(Sims.Li_O_ratios, lifetimes, marker="o")
+    ax.set(xlabel=xlabel, ylabel="Relaxation Time / ns", xlim=xlim)
+    equalize_xticks(ax)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title_base)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")


### PR DESCRIPTION
# Create Scripts to Plot Lifetime Autocorrelation Functions

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

* New Python script `scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_chain-length_dependence.py` that plots the lifetime autocorrelation function for two given compounds as function of the PEO chain length.
* New Python script `scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_conc_dependence.py` that plots the lifetime autocorrelation function for two given compounds as function of the salt concentration.
* New Python script `scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_chain-length_dependence.py` that plots the lifetime autocorrelation function for a given set of compound pairs as function of the PEO chain length.
* New Python script `scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_conc_dependence.py` that plots the lifetime autocorrelation function for a given set of compound pairs as function of the salt concentration.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] The CI workflow is passing.
