### PR TITLE
New Scripts to Extract and Plot Renewal Times

### DIFF
--- a/scripts/bulk_and_walls/mdt/discrete-z/get_and_plot_bin_lifetimes.py
+++ b/scripts/bulk_and_walls/mdt/discrete-z/get_and_plot_bin_lifetimes.py
@@ -7,8 +7,8 @@ Calculate bin residence times / lifetimes.
 For a single simulation, calculate the average time that a given
 compound stays in a given bin directly from the discrete trajectory
 (Method 1-3), from the corresponding remain probability function
-(Method 4-7) of from the corresponding Kaplan-Meier estimate of the
-survival function.
+(Method 4-6) of from the corresponding Kaplan-Meier estimate of the
+survival function (Method 7-9).
 """
 
 

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_chain-length_dependence.py
@@ -48,14 +48,15 @@ if len(args.cmps) == 0:
 settings = "pr_nvt423_nh"  # Simulation settings.
 analysis = "lifetime_autocorr"  # Analysis name.
 tool = "mdt"  # Analysis software.
-outfile = (  # Output file name.
+outfile_base = (  # Output file name.
     settings
     + "_lintf2_peoN_20-1_sc80_"
     + analysis
     + "_combined_"
     + "_".join(args.cmps)
-    + ".pdf"
 )
+outfile_txt = outfile_base + ".txt.gz"
+outfile_pdf = outfile_base + ".pdf"
 
 cols = (  # Columns to read from the input file(s).
     0,  # Lag times in [ps].
@@ -105,8 +106,8 @@ c_norm = max(Sims.n_sims - 1, 1)
 c_vals_normed = c_vals / c_norm
 colors = cmap(c_vals_normed)
 
-mdt.fh.backup(outfile)
-with PdfPages(outfile) as pdf:
+mdt.fh.backup(outfile_pdf)
+with PdfPages(outfile_pdf) as pdf:
     # Plot autocorrelation functions.
     for cmp_ix, cmp in enumerate(args.cmps):
         cmp1, cmp2 = cmp.split("-")
@@ -217,6 +218,22 @@ with PdfPages(outfile) as pdf:
         ax.set_xlim(xlim)
         pdf.savefig()
     plt.close()
+    print("Created {}".format(outfile_pdf))
 
-print("Created {}".format(outfile))
+
+print("Creating output file(s)...")
+header = (
+    "Coordination relaxation times.\n"
+    + "\n"
+    + "Average coordination relaxation times are calculated by numerical\n"
+    + "integration of the lifetime autocorrelation function."
+    + "\n\n"
+    + "The columns contain:\n"
+    + " 1 Number of ether oxygens per PEO chain\n"
+)
+for col, cmp in enumerate(args.cmps, start=2):
+    header += " {:d} {:s} relaxation time / ns\n".format(col, cmp)
+data = np.column_stack([Sims.O_per_chain, lifetimes.T])
+leap.io_handler.savetxt(outfile_txt, data, header=header)
+print("Created {}".format(outfile_txt))
 print("Done")

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_conc_dependence.py
@@ -69,7 +69,7 @@ if len(args.cmps) == 0:
 settings = "pr_nvt423_nh"  # Simulation settings.
 analysis = "lifetime_autocorr"  # Analysis name.
 tool = "mdt"  # Analysis software.
-outfile = (  # Output file name.
+outfile_base = (  # Output file name.
     settings
     + "_lintf2_"
     + args.sol
@@ -77,8 +77,9 @@ outfile = (  # Output file name.
     + analysis
     + "_combined_"
     + "_".join(args.cmps)
-    + ".pdf"
 )
+outfile_txt = outfile_base + ".txt.gz"
+outfile_pdf = outfile_base + ".pdf"
 
 cols = (  # Columns to read from the input file(s).
     0,  # Lag times in [ps].
@@ -128,8 +129,8 @@ c_norm = max(Sims.n_sims - 1, 1)
 c_vals_normed = c_vals / c_norm
 colors = cmap(c_vals_normed)
 
-mdt.fh.backup(outfile)
-with PdfPages(outfile) as pdf:
+mdt.fh.backup(outfile_pdf)
+with PdfPages(outfile_pdf) as pdf:
     # Plot autocorrelation functions.
     for cmp_ix, cmp in enumerate(args.cmps):
         cmp1, cmp2 = cmp.split("-")
@@ -227,6 +228,22 @@ with PdfPages(outfile) as pdf:
         ax.set_xlim(xlim)
         pdf.savefig()
     plt.close()
+    print("Created {}".format(outfile_pdf))
 
-print("Created {}".format(outfile))
+
+print("Creating output file(s)...")
+header = (
+    "Coordination relaxation times.\n"
+    + "\n"
+    + "Average coordination relaxation times are calculated by numerical\n"
+    + "integration of the lifetime autocorrelation function."
+    + "\n\n"
+    + "The columns contain:\n"
+    + " 1 Number of ether oxygens per PEO chain\n"
+)
+for col, cmp in enumerate(args.cmps, start=2):
+    header += " {:d} {:s} relaxation time / ns\n".format(col, cmp)
+data = np.column_stack([Sims.Li_O_ratios, lifetimes.T])
+leap.io_handler.savetxt(outfile_txt, data, header=header)
+print("Created {}".format(outfile_txt))
 print("Done")

--- a/scripts/bulk_and_walls/mdt/msd/plot_diff_coeff_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/msd/plot_diff_coeff_chain-length_dependence.py
@@ -192,6 +192,7 @@ xlim = (1, 200)
 labels = ("PEO", "TFSI", "Li")
 colors = ("tab:blue", "tab:orange", "tab:green")
 markers = ("o", "s", "^")
+legend_title = r"$r = %.2f$" % Sims.Li_O_ratios[0]
 
 mdt.fh.backup(outfile)
 with PdfPages(outfile) as pdf:
@@ -298,7 +299,7 @@ with PdfPages(outfile) as pdf:
         xlim=xlim,
         ylim=(1e-3, 2e1),
     )
-    ax.legend(loc="upper right")
+    ax.legend(title=legend_title, loc="upper right")
     pdf.savefig()
     plt.close()
 
@@ -314,7 +315,7 @@ with PdfPages(outfile) as pdf:
         )
     ax.set_xscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel="Fit Start / ns", xlim=xlim)
-    ax.legend()
+    ax.legend(title=legend_title)
     pdf.savefig()
     # Log scale y.
     ax.set_yscale("log", base=10, subs=np.arange(2, 10))
@@ -333,7 +334,7 @@ with PdfPages(outfile) as pdf:
         )
     ax.set_xscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel="Fit Stop / ns", xlim=xlim)
-    ax.legend()
+    ax.legend(title=legend_title)
     pdf.savefig()
     # Log scale y.
     ax.set_yscale("log", base=10, subs=np.arange(2, 10))
@@ -352,7 +353,7 @@ with PdfPages(outfile) as pdf:
         )
     ax.set_xscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel="Fit Stop - Start / ns", xlim=xlim)
-    ax.legend()
+    ax.legend(title=legend_title)
     pdf.savefig()
     # Log scale y.
     ax.set_yscale("log", base=10, subs=np.arange(2, 10))
@@ -371,7 +372,7 @@ with PdfPages(outfile) as pdf:
         )
     ax.set_xscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel=r"Coeff. of Determ. $R^2$", xlim=xlim)
-    ax.legend()
+    ax.legend(title=legend_title)
     pdf.savefig()
     # Log scale y.
     ax.set_yscale("log", base=10, subs=np.arange(2, 10))
@@ -391,7 +392,7 @@ with PdfPages(outfile) as pdf:
         )
     ax.set_xscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel=r"RMSE / nm$^2$", xlim=xlim)
-    ax.legend()
+    ax.legend(title=legend_title)
     pdf.savefig()
     # Log scale y.
     ax.set_yscale("log", base=10, subs=np.arange(2, 10))

--- a/scripts/bulk_and_walls/mdt/msd/plot_diff_coeff_chain-length_dependence_exp.py
+++ b/scripts/bulk_and_walls/mdt/msd/plot_diff_coeff_chain-length_dependence_exp.py
@@ -270,7 +270,9 @@ with PdfPages(outfile) as pdf:
     ax.set_yscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
     ax.legend(
-        loc="upper right", title="$303$ K", **mdtplt.LEGEND_KWARGS_XSMALL
+        loc="upper right",
+        title="$r = 0.05$, $303$ K",
+        **mdtplt.LEGEND_KWARGS_XSMALL,
     )
     pdf.savefig()
     plt.close()
@@ -352,7 +354,7 @@ with PdfPages(outfile) as pdf:
     ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
     legend = ax.legend(
         loc="upper right",
-        title="Hayamizu $333$ K",
+        title="$r = 0.05$\nHayamizu $333$ K",
         ncol=1,
         **mdtplt.LEGEND_KWARGS_XSMALL,
     )
@@ -396,7 +398,9 @@ with PdfPages(outfile) as pdf:
     ax.set_yscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
     ax.legend(
-        loc="upper right", title="$343$ K", **mdtplt.LEGEND_KWARGS_XSMALL
+        loc="upper right",
+        title="$r = 0.05$, $343$ K",
+        **mdtplt.LEGEND_KWARGS_XSMALL,
     )
     pdf.savefig()
     ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim_Shi, ylim=ylim)
@@ -439,7 +443,9 @@ with PdfPages(outfile) as pdf:
     ax.set_yscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
     ax.legend(
-        loc="upper right", title="$363$ K", **mdtplt.LEGEND_KWARGS_XSMALL
+        loc="upper right",
+        title="$r = 0.05$, $363$ K",
+        **mdtplt.LEGEND_KWARGS_XSMALL,
     )
     pdf.savefig()
     ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim_Shi, ylim=ylim)
@@ -608,7 +614,9 @@ with PdfPages(outfile) as pdf:
     ax.set_xscale("log", base=10, subs=np.arange(2, 10))
     ax.set_yscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
-    ax.legend(loc="upper right", **mdtplt.LEGEND_KWARGS_XSMALL)
+    ax.legend(
+        loc="upper right", title="$r = 0.05$", **mdtplt.LEGEND_KWARGS_XSMALL
+    )
     pdf.savefig()
     ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim_Shi, ylim=ylim)
     pdf.savefig()

--- a/scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_chain-length_dependence.py
@@ -99,14 +99,11 @@ analysis = "renewal_events"  # Analysis name.
 analysis_suffix = "_" + args.cmp  # Analysis name specification.
 ana_path = os.path.join(analysis, analysis + analysis_suffix)
 tool = "mdt"  # Analysis software.
-outfile = (  # Output file name.
-    settings
-    + "_lintf2_peoN_20-1_sc80_"
-    + analysis
-    + analysis_suffix
-    + con
-    + ".pdf"
+outfile_base = (  # Output file name.
+    settings + "_lintf2_peoN_20-1_sc80_" + analysis + analysis_suffix + con
 )
+outfile_txt = outfile_base + ".txt.gz"
+outfile_pdf = outfile_base + ".pdf"
 
 # Time conversion factor to convert trajectory steps to ns.
 time_conv = 2e-3
@@ -177,6 +174,10 @@ lts_rp_wbl_characs = np.full_like(lts_rp_int_characs, np.nan)
 lts_rp_wbl_fit_goodness = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
 popt_rp_wbl = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
 perr_rp_wbl = np.full_like(popt_rp_wbl, np.nan)
+tau0_rp_wbl = np.full(Sims.n_sims, np.nan, dtype=np.float32)
+tau0_rp_wbl_sd = np.full_like(tau0_rp_wbl, np.nan)
+beta_rp_wbl = np.full_like(tau0_rp_wbl, np.nan)
+beta_rp_wbl_sd = np.full_like(tau0_rp_wbl, np.nan)
 
 lts_rp_brr_characs = np.full_like(lts_rp_int_characs, np.nan)
 lts_rp_brr_fit_goodness = np.full_like(lts_rp_wbl_fit_goodness, np.nan)
@@ -184,6 +185,12 @@ popt_rp_brr = np.full((Sims.n_sims, 3), np.nan, dtype=np.float32)
 perr_rp_brr = np.full_like(popt_rp_brr, np.nan)
 popt_conv_rp_brr = np.full_like(popt_rp_brr, np.nan)
 perr_conv_rp_brr = np.full_like(popt_rp_brr, np.nan)
+tau0_rp_brr = np.full(Sims.n_sims, np.nan, dtype=np.float32)
+tau0_rp_brr_sd = np.full_like(tau0_rp_brr, np.nan)
+beta_rp_brr = np.full_like(tau0_rp_brr, np.nan)
+beta_rp_brr_sd = np.full_like(tau0_rp_brr, np.nan)
+delta_rp_brr = np.full_like(tau0_rp_brr, np.nan)
+delta_rp_brr_sd = np.full_like(tau0_rp_brr, np.nan)
 
 for sim_ix, Sim in enumerate(Sims.sims):
     # Read remain probability.
@@ -239,6 +246,8 @@ for sim_ix, Sim in enumerate(Sims.sims):
     lts_rp_wbl_fit_goodness[sim_ix] = np.squeeze(lts_rp_wbl_fit_goodness_sim)
     popt_rp_wbl[sim_ix] = np.squeeze(popt_rp_wbl_sim)
     perr_rp_wbl[sim_ix] = np.squeeze(perr_rp_wbl_sim)
+    tau0_rp_wbl[sim_ix], beta_rp_wbl[sim_ix] = popt_rp_wbl[sim_ix].T
+    tau0_rp_wbl_sd[sim_ix], beta_rp_wbl_sd[sim_ix] = perr_rp_wbl[sim_ix].T
     # Method 6: Burr Type XII fit of the remain probability.
     (
         lts_rp_brr_characs_sim,
@@ -261,6 +270,16 @@ for sim_ix, Sim in enumerate(Sims.sims):
     perr_rp_brr[sim_ix] = np.squeeze(perr_rp_brr_sim)
     popt_conv_rp_brr[sim_ix] = np.squeeze(popt_conv_rp_brr_sim)
     perr_conv_rp_brr[sim_ix] = np.squeeze(perr_conv_rp_brr_sim)
+    (
+        tau0_rp_brr[sim_ix],
+        beta_rp_brr[sim_ix],
+        delta_rp_brr[sim_ix],
+    ) = popt_conv_rp_brr[sim_ix].T
+    (
+        tau0_rp_brr_sd[sim_ix],
+        beta_rp_brr_sd[sim_ix],
+        delta_rp_brr_sd[sim_ix],
+    ) = perr_conv_rp_brr[sim_ix].T
 del remain_prob_sim
 del lts_rp_int_characs_sim
 del fit_start_rp_sim, fit_stop_rp_sim
@@ -296,6 +315,10 @@ lts_km_wbl_characs = np.full_like(lts_km_int_characs, np.nan)
 lts_km_wbl_fit_goodness = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
 popt_km_wbl = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
 perr_km_wbl = np.full_like(popt_km_wbl, np.nan)
+tau0_km_wbl = np.full(Sims.n_sims, np.nan, dtype=np.float32)
+tau0_km_wbl_sd = np.full_like(tau0_km_wbl, np.nan)
+beta_km_wbl = np.full_like(tau0_km_wbl, np.nan)
+beta_km_wbl_sd = np.full_like(tau0_km_wbl, np.nan)
 
 lts_km_brr_characs = np.full_like(lts_km_int_characs, np.nan)
 lts_km_brr_fit_goodness = np.full_like(lts_km_wbl_fit_goodness, np.nan)
@@ -303,6 +326,12 @@ popt_km_brr = np.full((Sims.n_sims, 3), np.nan, dtype=np.float32)
 perr_km_brr = np.full_like(popt_km_brr, np.nan)
 popt_conv_km_brr = np.full_like(popt_km_brr, np.nan)
 perr_conv_km_brr = np.full_like(popt_km_brr, np.nan)
+tau0_km_brr = np.full(Sims.n_sims, np.nan, dtype=np.float32)
+tau0_km_brr_sd = np.full_like(tau0_km_brr, np.nan)
+beta_km_brr = np.full_like(tau0_km_brr, np.nan)
+beta_km_brr_sd = np.full_like(tau0_km_brr, np.nan)
+delta_km_brr = np.full_like(tau0_km_brr, np.nan)
+delta_km_brr_sd = np.full_like(tau0_km_brr, np.nan)
 
 for sim_ix, Sim in enumerate(Sims.sims):
     # Read Kaplan-Meier survival function.
@@ -358,6 +387,8 @@ for sim_ix, Sim in enumerate(Sims.sims):
     lts_km_wbl_fit_goodness[sim_ix] = np.squeeze(lts_km_wbl_fit_goodness_sim)
     popt_km_wbl[sim_ix] = np.squeeze(popt_km_wbl_sim)
     perr_km_wbl[sim_ix] = np.squeeze(perr_km_wbl_sim)
+    tau0_km_wbl[sim_ix], beta_km_wbl[sim_ix] = popt_km_wbl[sim_ix].T
+    tau0_km_wbl_sd[sim_ix], beta_km_wbl_sd[sim_ix] = perr_km_wbl[sim_ix].T
     # Method 9: Burr Type XII fit of the Kaplan-Meier estimator.
     (
         lts_km_brr_characs_sim,
@@ -381,6 +412,16 @@ for sim_ix, Sim in enumerate(Sims.sims):
     perr_km_brr[sim_ix] = np.squeeze(perr_km_brr_sim)
     popt_conv_km_brr[sim_ix] = np.squeeze(popt_conv_km_brr_sim)
     perr_conv_km_brr[sim_ix] = np.squeeze(perr_conv_km_brr_sim)
+    (
+        tau0_km_brr[sim_ix],
+        beta_km_brr[sim_ix],
+        delta_km_brr[sim_ix],
+    ) = popt_conv_km_brr[sim_ix].T
+    (
+        tau0_km_brr_sd[sim_ix],
+        beta_km_brr_sd[sim_ix],
+        delta_km_brr_sd[sim_ix],
+    ) = perr_conv_km_brr[sim_ix].T
 del km_surv_func_sim, km_surv_func_var_sim
 del lts_km_int_characs_sim
 del fit_start_km_sim, fit_stop_km_sim
@@ -399,6 +440,157 @@ del (
     perr_conv_km_brr_sim,
 )
 km_surv_funcs = np.asarray(km_surv_funcs)
+
+
+print("Creating output file(s)...")
+xdata = Sims.O_per_chain
+data = np.column_stack(
+    [
+        xdata,  # 1
+        # Method 1: Censored counting.
+        lts_cnt_cen_characs,  # 2-15
+        # Method 2: Uncensored counting.
+        lts_cnt_unc_characs,  # 16-29
+        # Method 3: Inverse transition rate.
+        lts_k,  # 30
+        # Method 4: Numerical integration of the remain probability.
+        lts_rp_int_characs,  # 31-40
+        # Method 5: Weibull fit of the remain probability.
+        lts_rp_wbl_characs,  # 41-50
+        tau0_rp_wbl,  # 51
+        tau0_rp_wbl_sd,  # 52
+        beta_rp_wbl,  # 53
+        beta_rp_wbl_sd,  # 54
+        lts_rp_wbl_fit_goodness,  # 55-56
+        # Method 6: Burr Type XII fit of the remain probability.
+        lts_rp_brr_characs,  # 57-66
+        tau0_rp_brr,  # 67
+        tau0_rp_brr_sd,  # 68
+        beta_rp_brr,  # 69
+        beta_rp_brr_sd,  # 70
+        delta_rp_brr,  # 71
+        delta_rp_brr_sd,  # 72
+        lts_rp_brr_fit_goodness,  # 73-74
+        # Fit region for the remain probability.
+        fit_start_rp * time_conv,  # 75
+        (fit_stop_rp - 1) * time_conv,  # 76
+        # Method 7: Numerical integration of the Kaplan-Meier estimator.
+        lts_km_int_characs,  # 77-86
+        # Method 8: Weibull fit of the Kaplan-Meier estimator.
+        lts_km_wbl_characs,  # 87-96
+        tau0_km_wbl,  # 97
+        tau0_km_wbl_sd,  # 98
+        beta_km_wbl,  # 99
+        beta_km_wbl_sd,  # 100
+        lts_km_wbl_fit_goodness,  # 101-102
+        # Method 9: Burr Type XII fit of the Kaplan-Meier estimator.
+        lts_km_brr_characs,  # 103-112
+        tau0_km_brr,  # 113
+        tau0_km_brr_sd,  # 114
+        beta_km_brr,  # 115
+        beta_km_brr_sd,  # 116
+        delta_km_brr,  # 117
+        delta_km_brr_sd,  # 118
+        lts_km_brr_fit_goodness,  # 119-120
+        # Fit region for the Kaplan-Meier estimator.
+        fit_start_km * time_conv,  # 121
+        (fit_stop_km - 1) * time_conv,  # 122
+    ]
+)
+header = (
+    "{} renewal times.\n".format(args.cmp)
+    + "The renewal time is the average time after which the selection\n"
+    + "compound ('{}') that was continuously bound the longest to\n".format(
+        cmp2
+    )
+    + "a reference compound ('{}') dissociates from it.\n".format(cmp1)
+    + "\n"
+    + "Lithium-to-ether-oxygen ratio: {:.2f}\n".format(Sims.Li_O_ratios[0])
+    + "int_thresh = {:.4f}\n".format(args.int_thresh)
+    + "end_fit  = {}\n".format(args.end_fit)
+    + "stop_fit = {:.4f}\n".format(args.stop_fit)
+    + "\n"
+    + "\n"
+    + "The columns contain:\n"
+    + "  1 Number of ether oxygens per PEO chain\n"
+    + "\n"
+    + "Methods based on counting frames:\n"
+    + "  Method 1: Censored counting\n"
+    + "  2 Sample mean (1st raw moment) / ns\n"
+    + "  3 Uncertainty of the sample mean (standard error) / ns\n"
+    + "  4 Corrected sample standard deviation / ns\n"
+    + "  5 Corrected coefficient of variation\n"
+    + "  6 Unbiased sample skewness (Fisher)\n"
+    + "  7 Unbiased sample excess kurtosis (Fisher)\n"
+    + "  8 Sample median / ns\n"
+    + "  9 Non-parametric skewness\n"
+    + " 10 2nd raw moment (biased estimate) / ns^2\n"
+    + " 11 3rd raw moment (biased estimate) / ns^3\n"
+    + " 12 4th raw moment (biased estimate) / ns^4\n"
+    + " 13 Sample minimum / ns\n"
+    + " 14 Sample maximum / ns\n"
+    + " 15 Number of observations/samples\n"
+    + "\n"
+    + "  Method 2: Uncensored counting.\n"
+    + " 16-29 As Method 1\n"
+    + "\n"
+    + "  Method 3: Inverse transition rate\n"
+    + " 30 Mean renewal time / ns\n"
+    + "\n"
+    + "Methods based on the ACF:\n"
+    + "  Method 4: Numerical integration of the ACF\n"
+    + " 31 Mean renewal time (1st raw moment) / ns\n"
+    + " 32 Standard deviation / ns\n"
+    + " 33 Coefficient of variation"
+    + " 34 Skewness (Fisher)\n"
+    + " 35 Excess kurtosis (Fisher)\n"
+    + " 36 Median / ns\n"
+    + " 37 Non-parametric skewness\n"
+    + " 38 2nd raw moment / ns^2\n"
+    + " 39 3rd raw moment / ns^3\n"
+    + " 40 4th raw moment / ns^4\n"
+    + "\n"
+    + "  Method 5: Weibull fit of the ACF\n"
+    + " 41-50 As Method 4\n"
+    + " 51 Fit parameter tau0_wbl / ns\n"
+    + " 52 Standard deviation of tau0_wbl / ns\n"
+    + " 53 Fit parameter beta_wbl\n"
+    + " 54 Standard deviation of beta_wbl\n"
+    + " 55 Coefficient of determination of the fit (R^2 value)\n"
+    + " 56 Root-mean-square error (RMSE) of the fit\n"
+    + "\n"
+    + "  Method 6: Burr Type XII fit of the ACF\n"
+    + " 57-70 As Method 5\n"
+    + " 71 Fit parameter delta_brr\n"
+    + " 72 Standard deviation of delta_brr\n"
+    + " 73 Coefficient of determination of the fit (R^2 value)\n"
+    + " 74 Root-mean-square error (RMSE) of the fit\n"
+    + "\n"
+    + "  Fit region for all ACF fitting methods\n"
+    + " 75 Start of fit region (inclusive) / ns\n"
+    + " 76 End of fit region (inclusive) / ns\n"
+    + "\n"
+    + "Methods based on the Kaplan-Meier estimator:\n"
+    + "  Method 7: Numerical integration of the Kaplan-Meier estimator\n"
+    + " 77-86 As Method 4\n"
+    + "\n"
+    + "  Method 8: Weibull fit of the Kaplan-Meier estimator\n"
+    + " 87-102 As Method 5\n"
+    + "\n"
+    + "  Method 9: Burr Type XII fit of the Kaplan-Meier estimator\n"
+    + " 103-120 As Method 6\n"
+    + "\n"
+    + "  Fit region for all Kaplan-Meier estimator fitting methods\n"
+    + " 121 Start of fit region (inclusive) / ns\n"
+    + " 122 End of fit region (inclusive) / ns\n"
+    + "\n"
+    + "Column number:\n"
+)
+header += "{:>14d}".format(1)
+for i in range(2, data.shape[-1] + 1):
+    header += " {:>16d}".format(i)
+leap.io_handler.savetxt(outfile_txt, data, header=header)
+print("Created {}".format(outfile_txt))
 
 
 print("Creating plot(s)...")
@@ -444,7 +636,6 @@ ylabel_acf = "Autocorrelation Function"
 ylabel_km = "Kaplan-Meier Estimate"
 
 xlabel = r"Ether Oxygens per Chain $n_{EO}$"
-xdata = Sims.O_per_chain
 xlim = (1, 200)
 legend_title = (
     r"$"
@@ -464,8 +655,8 @@ c_norm = max(1, Sims.n_sims - 1)
 c_vals_normed = c_vals / c_norm
 colors = cmap(c_vals_normed)
 
-mdt.fh.backup(outfile)
-with PdfPages(outfile) as pdf:
+mdt.fh.backup(outfile_pdf)
+with PdfPages(outfile_pdf) as pdf:
     # Plot distribution characteristics vs. chain length.
     ylabels = (
         "Renewal Time / ns",
@@ -1159,5 +1350,5 @@ with PdfPages(outfile) as pdf:
     pdf.savefig()
     plt.close()
 
-print("Created {}".format(outfile))
+print("Created {}".format(outfile_pdf))
 print("Done")

--- a/scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_chain-length_dependence.py
@@ -1,0 +1,1163 @@
+#!/usr/bin/env python3
+
+
+"""
+Calculate and plot the renewal time for a given pair of compounds as
+function of the PEO chain length.
+
+Calculate the time until the PEO chain (or more generally the ligand)
+that was bound the longest to the central ion detaches form the central
+ion.  The renewal time is calculated directly from the discrete
+trajectory (Method 1-3), from the corresponding remain probability
+function (Method 4-6) of from the corresponding Kaplan-Meier estimate of
+the survival function (Method 7-9).
+
+See
+:file:`scripts/bulk_and_walls/mdt/discrete-z/get_and_plot_bin_lifetimes.py`
+for more details about the calculation methods.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Calculate and plot the renewal time for a given pair of compounds as"
+        " function of the PEO chain length."
+    )
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=True,
+    choices=("Li-ether", "Li-NTf2"),
+    help="Compounds for which to calculate the renewal times.",
+)
+parser.add_argument(
+    "--continuous",
+    required=False,
+    default=False,
+    action="store_true",
+    help="Use the 'continuous' definition of the remain probability function.",
+)
+parser.add_argument(
+    "--int-thresh",
+    type=float,
+    required=False,
+    default=0.01,
+    help=(
+        "Only calculate the renewal time by directly integrating the remain"
+        " probability if the remain probability decayed below the given"
+        " threshold.  Default:  %(default)s."
+    ),
+)
+parser.add_argument(
+    "--end-fit",
+    type=float,
+    required=False,
+    default=None,
+    help=(
+        "Last lag time (in ns) to include when fitting the remain probability."
+        "  Default:  %(default)s (this means end at 90%% of the lag times)."
+    ),
+)
+parser.add_argument(
+    "--stop-fit",
+    type=float,
+    required=False,
+    default=0.01,
+    help=(
+        "Stop fitting the remain probability as soon as it falls below this"
+        " threshold.  The fitting is stopped by whatever happens earlier:"
+        " --end-fit or --stop-fit.  Default: %(default)s"
+    ),
+)
+args = parser.parse_args()
+cmp1, cmp2 = args.cmp.split("-")
+
+if args.continuous:
+    con = "_continuous"
+else:
+    con = ""
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+analysis = "renewal_events"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+ana_path = os.path.join(analysis, analysis + analysis_suffix)
+tool = "mdt"  # Analysis software.
+outfile = (  # Output file name.
+    settings
+    + "_lintf2_peoN_20-1_sc80_"
+    + analysis
+    + analysis_suffix
+    + con
+    + ".pdf"
+)
+
+# Time conversion factor to convert trajectory steps to ns.
+time_conv = 2e-3
+# Number of moments to calculate.  For calculating the skewness, the 2nd
+# and 3rd (central) moments are required, for the kurtosis the 2nd and
+# 4th (central) moments are required.
+n_moms = 4
+# Fit method of `scipy.optimize.curve_fit` to use for all fits.
+fit_method = "trf"
+
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_[gp]*[0-9]*_20-1_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, path_key="bulk", sort_key="O_per_chain"
+)
+
+
+print("Calculating renewal times directly from `dtrj`...")
+lts_cnt_cen_characs = np.full(
+    (Sims.n_sims, 10 + n_moms), np.nan, dtype=np.float32
+)
+lts_cnt_unc_characs = np.full_like(lts_cnt_cen_characs, np.nan)
+lts_k = np.full(Sims.n_sims, np.nan, dtype=np.float32)
+for sim_ix, Sim in enumerate(Sims.sims):
+    # Read discrete trajectory.
+    file_suffix = analysis + analysis_suffix + "_dtrj.npz"
+    infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    dtrj = mdt.fh.load_dtrj(infile)
+    # Method 1: Censored counting.
+    lts_cnt_cen_characs[sim_ix] = leap.lifetimes.count_method_state_average(
+        dtrj,
+        n_moms=n_moms,
+        time_conv=time_conv,
+        uncensored=False,
+        discard_neg_start=True,
+    )
+    # Method 2: Uncensored counting.
+    lts_cnt_unc_characs[sim_ix] = leap.lifetimes.count_method_state_average(
+        dtrj,
+        n_moms=n_moms,
+        time_conv=time_conv,
+        uncensored=True,
+        discard_neg_start=True,
+    )
+    # Method 3: Calculate the transition rate as the number of
+    # transitions leading out of a given state divided by the number of
+    # frames that compounds have spent in this state.  The average
+    # renewal time is calculated as the inverse transition rate.
+    rate = mdt.dtrj.trans_rate_tot(dtrj, discard_neg_start=True)
+    lts_k[sim_ix] = time_conv / rate
+del dtrj, rate
+
+
+print("Calculating renewal times from the remain probability...")
+times_prev = None
+remain_probs = [None for Sim in Sims.sims]
+
+lts_rp_int_characs = np.full(
+    (Sims.n_sims, 6 + n_moms), np.nan, dtype=np.float32
+)
+
+fit_start_rp = np.zeros(Sims.n_sims, dtype=np.uint32)
+fit_stop_rp = np.zeros_like(fit_start_rp)
+
+lts_rp_wbl_characs = np.full_like(lts_rp_int_characs, np.nan)
+lts_rp_wbl_fit_goodness = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
+popt_rp_wbl = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
+perr_rp_wbl = np.full_like(popt_rp_wbl, np.nan)
+
+lts_rp_brr_characs = np.full_like(lts_rp_int_characs, np.nan)
+lts_rp_brr_fit_goodness = np.full_like(lts_rp_wbl_fit_goodness, np.nan)
+popt_rp_brr = np.full((Sims.n_sims, 3), np.nan, dtype=np.float32)
+perr_rp_brr = np.full_like(popt_rp_brr, np.nan)
+popt_conv_rp_brr = np.full_like(popt_rp_brr, np.nan)
+perr_conv_rp_brr = np.full_like(popt_rp_brr, np.nan)
+
+for sim_ix, Sim in enumerate(Sims.sims):
+    # Read remain probability.
+    file_suffix = (
+        analysis
+        + analysis_suffix
+        + "_state_lifetime_discard-neg-start"
+        + con
+        + ".txt.gz"
+    )
+    infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    times, remain_prob_sim = np.loadtxt(
+        infile, usecols=(0, 1), unpack=True, dtype=np.float32
+    )
+    if times_prev is not None and not np.array_equal(times, times_prev):
+        # Saving the lag times for all simulations would be quite memory
+        # consuming.  Because in my case all simulations should have the
+        # same lag times, I am just saving one lag time array.
+        raise ValueError("The lag times of the different simulations differ")
+    times_prev = np.copy(times)
+    times *= time_conv
+    remain_probs[sim_ix] = remain_prob_sim
+    # Add an additional dimension to `remain_prob_sim`, because the used
+    # functions from `lintf2_ether_ana_postproc.lifetimes` expect an
+    # array of survival functions.
+    remain_prob_sim = remain_prob_sim.reshape(remain_prob_sim.shape + (1,))
+    # Method 4: Numerical integration of the remain probability.
+    lts_rp_int_characs_sim = leap.lifetimes.integral_method(
+        remain_prob_sim, times, n_moms=n_moms, int_thresh=args.int_thresh
+    )
+    lts_rp_int_characs[sim_ix] = np.squeeze(lts_rp_int_characs_sim)
+    # Get fit region for fitting methods.
+    fit_start_rp_sim, fit_stop_rp_sim = leap.lifetimes.get_fit_region(
+        remain_prob_sim, times, end_fit=args.end_fit, stop_fit=args.stop_fit
+    )
+    fit_start_rp[sim_ix] = fit_start_rp_sim[0]
+    fit_stop_rp[sim_ix] = fit_stop_rp_sim[0]
+    # Method 5: Weibull fit of the remain probability.
+    (
+        lts_rp_wbl_characs_sim,
+        lts_rp_wbl_fit_goodness_sim,
+        popt_rp_wbl_sim,
+        perr_rp_wbl_sim,
+    ) = leap.lifetimes.weibull_fit_method(
+        remain_prob_sim,
+        times,
+        fit_start=fit_start_rp_sim,
+        fit_stop=fit_stop_rp_sim,
+        n_moms=n_moms,
+        fit_method=fit_method,
+    )
+    lts_rp_wbl_characs[sim_ix] = np.squeeze(lts_rp_wbl_characs_sim)
+    lts_rp_wbl_fit_goodness[sim_ix] = np.squeeze(lts_rp_wbl_fit_goodness_sim)
+    popt_rp_wbl[sim_ix] = np.squeeze(popt_rp_wbl_sim)
+    perr_rp_wbl[sim_ix] = np.squeeze(perr_rp_wbl_sim)
+    # Method 6: Burr Type XII fit of the remain probability.
+    (
+        lts_rp_brr_characs_sim,
+        lts_rp_brr_fit_goodness_sim,
+        popt_rp_brr_sim,
+        perr_rp_brr_sim,
+        popt_conv_rp_brr_sim,
+        perr_conv_rp_brr_sim,
+    ) = leap.lifetimes.burr12_fit_method(
+        remain_prob_sim,
+        times,
+        fit_start=fit_start_rp_sim,
+        fit_stop=fit_stop_rp_sim,
+        n_moms=n_moms,
+        fit_method=fit_method,
+    )
+    lts_rp_brr_characs[sim_ix] = np.squeeze(lts_rp_brr_characs_sim)
+    lts_rp_brr_fit_goodness[sim_ix] = np.squeeze(lts_rp_brr_fit_goodness_sim)
+    popt_rp_brr[sim_ix] = np.squeeze(popt_rp_brr_sim)
+    perr_rp_brr[sim_ix] = np.squeeze(perr_rp_brr_sim)
+    popt_conv_rp_brr[sim_ix] = np.squeeze(popt_conv_rp_brr_sim)
+    perr_conv_rp_brr[sim_ix] = np.squeeze(perr_conv_rp_brr_sim)
+del remain_prob_sim
+del lts_rp_int_characs_sim
+del fit_start_rp_sim, fit_stop_rp_sim
+del (
+    lts_rp_wbl_characs_sim,
+    lts_rp_wbl_fit_goodness_sim,
+    popt_rp_wbl_sim,
+    perr_rp_wbl_sim,
+)
+del (
+    lts_rp_brr_characs_sim,
+    lts_rp_brr_fit_goodness_sim,
+    popt_rp_brr_sim,
+    perr_rp_brr_sim,
+    popt_conv_rp_brr_sim,
+    perr_conv_rp_brr_sim,
+)
+remain_probs = np.asarray(remain_probs)
+
+
+print("Calculating renewal times from the Kaplan-Meier estimator...")
+times_prev = None
+km_surv_funcs = [None for Sim in Sims.sims]
+
+lts_km_int_characs = np.full(
+    (Sims.n_sims, 6 + n_moms), np.nan, dtype=np.float32
+)
+
+fit_start_km = np.zeros(Sims.n_sims, dtype=np.uint32)
+fit_stop_km = np.zeros_like(fit_start_km)
+
+lts_km_wbl_characs = np.full_like(lts_km_int_characs, np.nan)
+lts_km_wbl_fit_goodness = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
+popt_km_wbl = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
+perr_km_wbl = np.full_like(popt_km_wbl, np.nan)
+
+lts_km_brr_characs = np.full_like(lts_km_int_characs, np.nan)
+lts_km_brr_fit_goodness = np.full_like(lts_km_wbl_fit_goodness, np.nan)
+popt_km_brr = np.full((Sims.n_sims, 3), np.nan, dtype=np.float32)
+perr_km_brr = np.full_like(popt_km_brr, np.nan)
+popt_conv_km_brr = np.full_like(popt_km_brr, np.nan)
+perr_conv_km_brr = np.full_like(popt_km_brr, np.nan)
+
+for sim_ix, Sim in enumerate(Sims.sims):
+    # Read Kaplan-Meier survival function.
+    file_suffix = (
+        analysis + analysis_suffix + "_kaplan_meier_discard-neg-start.txt.gz"
+    )
+    infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    times, km_surv_func_sim, km_surv_func_var_sim = np.loadtxt(
+        infile, unpack=True, dtype=np.float32
+    )
+    if times_prev is not None and not np.array_equal(times, times_prev):
+        # Saving the lag times for all simulations would be quite memory
+        # consuming.  Because in my case all simulations should have the
+        # same lag times, I am just saving one lag time array.
+        raise ValueError("The lag times of the different simulations differ")
+    times_prev = np.copy(times)
+    times *= time_conv
+    km_surv_funcs[sim_ix] = km_surv_func_sim
+    # Add an additional dimension to `km_surv_func_sim`, because the
+    # used functions from `lintf2_ether_ana_postproc.lifetimes` expect
+    # an array of survival functions.
+    km_surv_func_sim = km_surv_func_sim.reshape(km_surv_func_sim.shape + (1,))
+    km_surv_func_var_sim = km_surv_func_var_sim.reshape(
+        km_surv_func_var_sim.shape + (1,)
+    )
+    # Method 7: Numerical integration of the Kaplan-Meier estimator.
+    lts_km_int_characs_sim = leap.lifetimes.integral_method(
+        km_surv_func_sim, times, n_moms=n_moms, int_thresh=args.int_thresh
+    )
+    lts_km_int_characs[sim_ix] = np.squeeze(lts_km_int_characs_sim)
+    # Get fit region for fitting methods.
+    fit_start_km_sim, fit_stop_km_sim = leap.lifetimes.get_fit_region(
+        km_surv_func_sim, times, end_fit=args.end_fit, stop_fit=args.stop_fit
+    )
+    fit_start_km[sim_ix] = fit_start_km_sim[0]
+    fit_stop_km[sim_ix] = fit_stop_km_sim[0]
+    # Method 8: Weibull fit of the Kaplan-Meier estimator.
+    (
+        lts_km_wbl_characs_sim,
+        lts_km_wbl_fit_goodness_sim,
+        popt_km_wbl_sim,
+        perr_km_wbl_sim,
+    ) = leap.lifetimes.weibull_fit_method(
+        km_surv_func_sim,
+        times,
+        fit_start=fit_start_km_sim,
+        fit_stop=fit_stop_km_sim,
+        surv_funcs_var=km_surv_func_var_sim,
+        n_moms=n_moms,
+        fit_method=fit_method,
+    )
+    lts_km_wbl_characs[sim_ix] = np.squeeze(lts_km_wbl_characs_sim)
+    lts_km_wbl_fit_goodness[sim_ix] = np.squeeze(lts_km_wbl_fit_goodness_sim)
+    popt_km_wbl[sim_ix] = np.squeeze(popt_km_wbl_sim)
+    perr_km_wbl[sim_ix] = np.squeeze(perr_km_wbl_sim)
+    # Method 9: Burr Type XII fit of the Kaplan-Meier estimator.
+    (
+        lts_km_brr_characs_sim,
+        lts_km_brr_fit_goodness_sim,
+        popt_km_brr_sim,
+        perr_km_brr_sim,
+        popt_conv_km_brr_sim,
+        perr_conv_km_brr_sim,
+    ) = leap.lifetimes.burr12_fit_method(
+        km_surv_func_sim,
+        times,
+        fit_start=fit_start_km_sim,
+        fit_stop=fit_stop_km_sim,
+        surv_funcs_var=km_surv_func_var_sim,
+        n_moms=n_moms,
+        fit_method=fit_method,
+    )
+    lts_km_brr_characs[sim_ix] = np.squeeze(lts_km_brr_characs_sim)
+    lts_km_brr_fit_goodness[sim_ix] = np.squeeze(lts_km_brr_fit_goodness_sim)
+    popt_km_brr[sim_ix] = np.squeeze(popt_km_brr_sim)
+    perr_km_brr[sim_ix] = np.squeeze(perr_km_brr_sim)
+    popt_conv_km_brr[sim_ix] = np.squeeze(popt_conv_km_brr_sim)
+    perr_conv_km_brr[sim_ix] = np.squeeze(perr_conv_km_brr_sim)
+del km_surv_func_sim, km_surv_func_var_sim
+del lts_km_int_characs_sim
+del fit_start_km_sim, fit_stop_km_sim
+del (
+    lts_km_wbl_characs_sim,
+    lts_km_wbl_fit_goodness_sim,
+    popt_km_wbl_sim,
+    perr_km_wbl_sim,
+)
+del (
+    lts_km_brr_characs_sim,
+    lts_km_brr_fit_goodness_sim,
+    popt_km_brr_sim,
+    perr_km_brr_sim,
+    popt_conv_km_brr_sim,
+    perr_conv_km_brr_sim,
+)
+km_surv_funcs = np.asarray(km_surv_funcs)
+
+
+print("Creating plot(s)...")
+label_cnt_cen = "Cens."  # Count
+label_cnt_unc = "Uncens."  # Count
+label_k = "Rate"
+label_rp_int = "ACF Num"
+label_rp_wbl = "ACF Wbl"
+label_rp_brr = "ACF Burr"
+label_km_int = "KM Num"
+label_km_wbl = "KM Wbl"
+label_km_brr = "KM Burr"
+
+color_cnt_cen = "tab:orange"
+color_cnt_unc = "tab:red"
+color_k = "tab:brown"
+color_rp_int = "tab:purple"
+color_rp_wbl = "tab:blue"
+color_rp_brr = "tab:cyan"
+color_km_int = "goldenrod"
+color_km_wbl = "gold"
+color_km_brr = "yellow"
+
+marker_cnt_cen = "H"
+marker_cnt_unc = "h"
+marker_k = "p"
+marker_rp_int = "^"
+marker_rp_wbl = ">"
+marker_rp_brr = "<"
+marker_km_int = "s"
+marker_km_wbl = "D"
+marker_km_brr = "d"
+
+color_exp = "tab:green"
+linestyle_exp = "dashed"
+label_exp = "Exp. Dist."
+
+label_sm = None
+color_sm = None
+marker_sm = "o"
+
+ylabel_acf = "Autocorrelation Function"
+ylabel_km = "Kaplan-Meier Estimate"
+
+xlabel = r"Ether Oxygens per Chain $n_{EO}$"
+xdata = Sims.O_per_chain
+xlim = (1, 200)
+legend_title = (
+    r"$"
+    + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp1]
+    + "-"
+    + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp2]
+    + r"$"
+    + "\n"
+    + r"$r = %.2f$" % Sims.Li_O_ratios[0]
+)
+legend_title_sf = legend_title + "\n" + r"$n_{EO}$"
+n_legend_col_sf = 1 + Sims.n_sims // (4 + 1)
+
+cmap = plt.get_cmap()
+c_vals = np.arange(Sims.n_sims)
+c_norm = max(1, Sims.n_sims - 1)
+c_vals_normed = c_vals / c_norm
+colors = cmap(c_vals_normed)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot distribution characteristics vs. chain length.
+    ylabels = (
+        "Renewal Time / ns",
+        "Std. Dev. / ns",
+        "Coeff. of Variation",
+        "Skewness",
+        "Excess Kurtosis",
+        "Median / ns",
+        "Non-Parametric Skewness",
+    )
+    for i, ylabel in enumerate(ylabels):
+        # Figure containing all methods.
+        fig, ax = plt.subplots(clear=True)
+        # Figure containing only the finally chosen method.
+        fig_single_method, ax_sm = plt.subplots(clear=True)
+        if i == 0:
+            offset_i_cnt = 0
+        else:
+            offset_i_cnt = 1
+        if ylabel == "Coeff. of Variation":
+            y_exp = 1  # Coeff. of variation of exp. distribution.
+        elif ylabel == "Skewness":
+            y_exp = 2  # Skewness of exponential distribution.
+        elif ylabel == "Excess Kurtosis":
+            y_exp = 6  # Excess kurtosis of exponential distribution.
+        elif ylabel == "Non-Parametric Skewness":
+            y_exp = 1 - np.log(2)  # Non-param. skew. of exp. dist.
+        else:
+            y_exp = None
+        if y_exp is not None:
+            ax.axhline(
+                y=y_exp,
+                color=color_exp,
+                linestyle=linestyle_exp,
+                label=label_exp,
+            )
+            ax_sm.axhline(
+                y=y_exp,
+                color=color_exp,
+                linestyle=linestyle_exp,
+                label=label_exp,
+            )
+        # Method 1: Censored counting.
+        ax.errorbar(
+            xdata,
+            lts_cnt_cen_characs[:, i + offset_i_cnt],
+            yerr=lts_cnt_cen_characs[:, i + 1] if i == 0 else None,
+            label=label_cnt_cen,
+            color=color_cnt_cen,
+            marker=marker_cnt_cen,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 2: Uncensored counting.
+        ax.errorbar(
+            xdata,
+            lts_cnt_unc_characs[:, i + offset_i_cnt],
+            yerr=lts_cnt_unc_characs[:, i + 1] if i == 0 else None,
+            label=label_cnt_unc,
+            color=color_cnt_unc,
+            marker=marker_cnt_unc,
+            alpha=leap.plot.ALPHA,
+        )
+        if i == 0:
+            # Method 3: Inverse transition rate.
+            ax.errorbar(
+                xdata,
+                lts_k,
+                yerr=None,
+                label=label_k,
+                color=color_k,
+                marker=marker_k,
+                alpha=leap.plot.ALPHA,
+            )
+            ax_sm.plot(
+                xdata, lts_k, label=label_sm, color=color_sm, marker=marker_sm
+            )
+        # Method 4: Numerical integration of the remain probability.
+        ax.errorbar(
+            xdata,
+            lts_rp_int_characs[:, i],
+            yerr=None,
+            label=label_rp_int,
+            color=color_rp_int,
+            marker=marker_rp_int,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 5: Weibull fit of the remain probability.
+        ax.errorbar(
+            xdata,
+            lts_rp_wbl_characs[:, i],
+            yerr=None,
+            label=label_rp_wbl,
+            color=color_rp_wbl,
+            marker=marker_rp_wbl,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 6: Burr Type XII fit of the remain probability.
+        ax.errorbar(
+            xdata,
+            lts_rp_brr_characs[:, i],
+            yerr=None,
+            label=label_rp_brr,
+            color=color_rp_brr,
+            marker=marker_rp_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 7: Numerical integration of the KM estimator.
+        ax.errorbar(
+            xdata,
+            lts_km_int_characs[:, i],
+            yerr=None,
+            label=label_km_int,
+            color=color_km_int,
+            marker=marker_km_int,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 8: Weibull fit of the Kaplan-Meier estimator.
+        ax.errorbar(
+            xdata,
+            lts_km_wbl_characs[:, i],
+            yerr=None,
+            label=label_km_wbl,
+            color=color_km_wbl,
+            marker=marker_km_wbl,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 9: Burr Type XII fit of the Kaplan-Meier estimator.
+        ax.errorbar(
+            xdata,
+            lts_km_brr_characs[:, i],
+            yerr=None,
+            label=label_km_brr,
+            color=color_km_brr,
+            marker=marker_km_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        ylim = ax.get_ylim()
+        if ylim[0] < 0 and ylabel not in (
+            "Skewness",
+            "Excess Kurtosis",
+            "Non-Parametric Skewness",
+        ):
+            ax.set_ylim(0, ylim[1])
+        legend = ax.legend(
+            title=legend_title, ncol=3, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig(fig)
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax.relim()
+            ax.autoscale()
+            ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax.set_xlim(xlim)
+            pdf.savefig(fig)
+        plt.close(fig)
+        # The finally chosen method.
+        ax_sm.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax_sm.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        ylim = ax_sm.get_ylim()
+        if ylim[0] < 0 and ylabel not in (
+            "Skewness",
+            "Excess Kurtosis",
+            "Non-Parametric Skewness",
+        ):
+            ax_sm.set_ylim(0, ylim[1])
+        legend = ax_sm.legend(
+            title=legend_title, ncol=3, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig(fig_single_method)
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax_sm)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax_sm.relim()
+            ax_sm.autoscale()
+            ax_sm.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax_sm.set_xlim(xlim)
+            pdf.savefig(fig_single_method)
+        plt.close(fig_single_method)
+
+    # Plot min, max and number of samples for count methods.
+    ylabels = (
+        "Min. Renewal Time / ns",
+        "Max. Renewal Time / ns",
+        "No. of Renewal Events",
+    )
+    for i, ylabel in enumerate(ylabels):
+        # Figure containing all methods.
+        fig, ax = plt.subplots(clear=True)
+        # Figure containing only the finally chosen method.
+        fig_single_method, ax_sm = plt.subplots(clear=True)
+        # Method 1: Censored counting.
+        ax.plot(
+            xdata,
+            lts_cnt_cen_characs[:, 11 + i],
+            label=label_cnt_cen,
+            color=color_cnt_cen,
+            marker=marker_cnt_cen,
+            alpha=leap.plot.ALPHA,
+        )
+        ax_sm.plot(
+            xdata,
+            lts_cnt_cen_characs[:, 11 + i],
+            label=label_sm,
+            color=color_sm,
+            marker=marker_sm,
+        )
+        # Method 2: Uncensored counting.
+        ax.plot(
+            xdata,
+            lts_cnt_unc_characs[:, 11 + i],
+            label=label_cnt_unc,
+            color=color_cnt_unc,
+            marker=marker_cnt_unc,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        ylim = ax.get_ylim()
+        if ylim[0] < 0:
+            ax.set_ylim(0, ylim[1])
+        legend = ax.legend(
+            title=legend_title, ncol=2, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig(fig)
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax.relim()
+            ax.autoscale()
+            ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax.set_xlim(xlim)
+            pdf.savefig(fig)
+        plt.close(fig)
+        # The finally chosen method.
+        ax_sm.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax_sm.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        ylim = ax_sm.get_ylim()
+        if ylim[0] < 0:
+            ax_sm.set_ylim(0, ylim[1])
+        legend = ax_sm.legend(
+            title=legend_title, ncol=2, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig(fig_single_method)
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax_sm)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax_sm.relim()
+            ax_sm.autoscale()
+            ax_sm.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax_sm.set_xlim(xlim)
+            pdf.savefig(fig_single_method)
+        plt.close(fig_single_method)
+
+    # Plot fit parameters tau0, beta and delta.
+    ylabels = (
+        r"Fit Parameter $\tau_0$ / ns",
+        r"Fit Parameter $\beta$",
+        r"Fit Parameter $\delta$",
+    )
+    for i, ylabel in enumerate(ylabels):
+        fig, ax = plt.subplots(clear=True)
+        if i < 2:
+            # Method 5: Weibull fit of the remain probability.
+            ax.errorbar(
+                xdata,
+                popt_rp_wbl[:, i],
+                yerr=perr_rp_wbl[:, i],
+                label=label_rp_wbl,
+                color=color_rp_wbl,
+                marker=marker_rp_wbl,
+                alpha=leap.plot.ALPHA,
+            )
+        # Method 6: Burr Type XII fit of the remain probability.
+        ax.errorbar(
+            xdata,
+            popt_conv_rp_brr[:, i],
+            yerr=perr_conv_rp_brr[:, i],
+            label=label_rp_brr,
+            color=color_rp_brr,
+            marker=marker_rp_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        if i < 2:
+            # Method 8: Weibull fit of the Kaplan-Meier estimator.
+            ax.errorbar(
+                xdata,
+                popt_km_wbl[:, i],
+                yerr=perr_km_wbl[:, i],
+                label=label_km_wbl,
+                color=color_km_wbl,
+                marker=marker_km_wbl,
+                alpha=leap.plot.ALPHA,
+            )
+        # Method 9: Burr Type XII fit of the Kaplan-Meier estimator.
+        ax.errorbar(
+            xdata,
+            popt_conv_km_brr[:, i],
+            yerr=perr_conv_km_brr[:, i],
+            label=label_km_brr,
+            color=color_km_brr,
+            marker=marker_km_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        ylim = ax.get_ylim()
+        if ylim[0] < 0:
+            ax.set_ylim(0, ylim[1])
+        legend = ax.legend(
+            title=legend_title, ncol=2, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax.relim()
+            ax.autoscale()
+            ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax.set_xlim(xlim)
+            pdf.savefig()
+        plt.close()
+
+    # Plot goodness of fit quantities.
+    ylabels = (r"Coeff. of Determ. $R^2$", "RMSE")
+    for i, ylabel in enumerate(ylabels):
+        fig, ax = plt.subplots(clear=True)
+        # Method 5: Weibull fit of the remain probability.
+        ax.plot(
+            xdata,
+            lts_rp_wbl_fit_goodness[:, i],
+            label=label_rp_wbl,
+            color=color_rp_wbl,
+            marker=marker_rp_wbl,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 6: Burr Type XII fit of the remain probability.
+        ax.plot(
+            xdata,
+            lts_rp_brr_fit_goodness[:, i],
+            label=label_rp_brr,
+            color=color_rp_brr,
+            marker=marker_rp_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 8: Weibull fit of the Kaplan-Meier estimator.
+        ax.plot(
+            xdata,
+            lts_km_wbl_fit_goodness[:, i],
+            label=label_km_wbl,
+            color=color_km_wbl,
+            marker=marker_km_wbl,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 9: Burr Type XII fit of the Kaplan-Meier estimator.
+        ax.plot(
+            xdata,
+            lts_km_brr_fit_goodness[:, i],
+            label=label_km_brr,
+            color=color_km_brr,
+            marker=marker_km_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        ylim = ax.get_ylim()
+        if ylim[0] < 0:
+            ax.set_ylim(0, ylim[1])
+        legend = ax.legend(
+            title=legend_title, ncol=2, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax.relim()
+            ax.autoscale()
+            ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax.set_xlim(xlim)
+            pdf.savefig()
+        plt.close()
+
+    # Plot end of fit region.
+    ylabel = "End of Fit Region / ns"
+    fig, ax = plt.subplots(clear=True)
+    # Fit of remain probability.
+    ax.plot(
+        xdata,
+        (fit_stop_rp - 1) * time_conv,
+        label="ACF",
+        color=color_rp_wbl,
+        marker=marker_rp_wbl,
+    )
+    # Fit of Kaplan-Meier estimator.
+    ax.plot(
+        xdata,
+        (fit_stop_km - 1) * time_conv,
+        label="KM",
+        color=color_km_wbl,
+        marker=marker_km_wbl,
+    )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(
+        title=legend_title, ncol=2, **mdtplt.LEGEND_KWARGS_XSMALL
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+    # Plot remain probabilities and Weibull fits.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        rp = remain_probs[sim_ix]
+        times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
+        fit = mdt.func.kww(times_fit, *popt_rp_wbl[sim_ix])
+        lines = ax.plot(
+            times,
+            rp,
+            label=r"$%d$" % Sim.O_per_chain,
+            linewidth=1,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.plot(
+            times_fit,
+            fit,
+            label="Wbl Fit" if sim_ix == Sims.n_sims - 1 else None,
+            linestyle="dashed",
+            color=lines[0].get_color(),
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel=ylabel_acf,
+        xlim=(times[1], times[-1]),
+        ylim=(0, 1),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+    # Plot Weibull fit residuals (remain probability).
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        rp = remain_probs[sim_ix]
+        times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
+        fit = mdt.func.kww(times_fit, *popt_rp_wbl[sim_ix])
+        res = rp[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]] - fit
+        ax.plot(
+            times_fit,
+            res,
+            label=r"$%d$" % Sim.O_per_chain,
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel="ACF Weibull Fit Res.",
+        xlim=(times[1], times[-1]),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot Kaplan-Meier estimates and Weibull fits.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        km = km_surv_funcs[sim_ix]
+        times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
+        fit = mdt.func.kww(times_fit, *popt_km_wbl[sim_ix])
+        lines = ax.plot(
+            times,
+            km,
+            label=r"$%d$" % Sim.O_per_chain,
+            linewidth=1,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.plot(
+            times_fit,
+            fit,
+            label="Wbl Fit" if sim_ix == Sims.n_sims - 1 else None,
+            linestyle="dashed",
+            color=lines[0].get_color(),
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel=ylabel_km,
+        xlim=(times[1], times[-1]),
+        ylim=(0, 1),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+    # Plot Weibull fit residuals (Kaplan-Meier).
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        km = km_surv_funcs[sim_ix]
+        times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
+        fit = mdt.func.kww(times_fit, *popt_km_wbl[sim_ix])
+        res = km[fit_start_km[sim_ix] : fit_stop_km[sim_ix]] - fit
+        ax.plot(
+            times_fit,
+            res,
+            label=r"$%d$" % Sim.O_per_chain,
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel="KM Weibull Fit Res.",
+        xlim=(times[1], times[-1]),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot remain probabilities and Burr fits.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        rp = remain_probs[sim_ix]
+        times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
+        fit = mdt.func.burr12_sf_alt(times_fit, *popt_rp_brr[sim_ix])
+        lines = ax.plot(
+            times,
+            rp,
+            label=r"$%d$" % Sim.O_per_chain,
+            linewidth=1,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.plot(
+            times_fit,
+            fit,
+            label="Burr Fit" if sim_ix == Sims.n_sims - 1 else None,
+            linestyle="dashed",
+            color=lines[0].get_color(),
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel=ylabel_acf,
+        xlim=(times[1], times[-1]),
+        ylim=(0, 1),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+    # Plot Burr fit residuals (remain probability).
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        rp = remain_probs[sim_ix]
+        times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
+        fit = mdt.func.burr12_sf_alt(times_fit, *popt_rp_brr[sim_ix])
+        res = rp[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]] - fit
+        ax.plot(
+            times_fit,
+            res,
+            label=r"$%d$" % Sim.O_per_chain,
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel="ACF Burr Fit Res.",
+        xlim=(times[1], times[-1]),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot Kaplan-Meier estimates and Burr fits for each state.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        km = km_surv_funcs[sim_ix]
+        times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
+        fit = mdt.func.burr12_sf_alt(times_fit, *popt_km_brr[sim_ix])
+        lines = ax.plot(
+            times,
+            km,
+            label=r"$%d$" % Sim.O_per_chain,
+            linewidth=1,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.plot(
+            times_fit,
+            fit,
+            label="Burr Fit" if sim_ix == Sims.n_sims - 1 else None,
+            linestyle="dashed",
+            color=lines[0].get_color(),
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel=ylabel_km,
+        xlim=(times[1], times[-1]),
+        ylim=(0, 1),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+    # Plot Burr fit residuals (Kaplan-Meier) for each state.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        km = km_surv_funcs[sim_ix]
+        times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
+        fit = mdt.func.burr12_sf_alt(times_fit, *popt_km_brr[sim_ix])
+        res = km[fit_start_km[sim_ix] : fit_stop_km[sim_ix]] - fit
+        ax.plot(
+            times_fit,
+            res,
+            label=r"$%d$" % Sim.O_per_chain,
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel="KM Burr Fit Res.",
+        xlim=(times[1], times[-1]),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_chain-length_dependence.py
@@ -846,8 +846,14 @@ with PdfPages(outfile_pdf) as pdf:
         "Min. Renewal Time / ns",
         "Max. Renewal Time / ns",
         "No. of Renewal Events",
+        "Renewal Events per Li Ion",
     )
     for i, ylabel in enumerate(ylabels):
+        if ylabel == "Renewal Events per Li Ion":
+            divisor = Sims.res_nums["cation"]
+            i = 2
+        else:
+            divisor = 1
         # Figure containing all methods.
         fig, ax = plt.subplots(clear=True)
         # Figure containing only the finally chosen method.
@@ -855,7 +861,7 @@ with PdfPages(outfile_pdf) as pdf:
         # Method 1: Censored counting.
         ax.plot(
             xdata,
-            lts_cnt_cen_characs[:, 11 + i],
+            lts_cnt_cen_characs[:, 11 + i] / divisor,
             label=label_cnt_cen,
             color=color_cnt_cen,
             marker=marker_cnt_cen,
@@ -863,7 +869,7 @@ with PdfPages(outfile_pdf) as pdf:
         )
         ax_sm.plot(
             xdata,
-            lts_cnt_cen_characs[:, 11 + i],
+            lts_cnt_cen_characs[:, 11 + i] / divisor,
             label=label_sm,
             color=color_sm,
             marker=marker_sm,
@@ -871,7 +877,7 @@ with PdfPages(outfile_pdf) as pdf:
         # Method 2: Uncensored counting.
         ax.plot(
             xdata,
-            lts_cnt_unc_characs[:, 11 + i],
+            lts_cnt_unc_characs[:, 11 + i] / divisor,
             label=label_cnt_unc,
             color=color_cnt_unc,
             marker=marker_cnt_unc,

--- a/scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_conc_dependence.py
@@ -159,7 +159,10 @@ lts_k = np.full(Sims.n_sims, np.nan, dtype=np.float32)
 for sim_ix, Sim in enumerate(Sims.sims):
     # Read discrete trajectory.
     file_suffix = analysis + analysis_suffix + "_dtrj.npz"
-    infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    try:
+        infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    except FileNotFoundError:
+        continue
     dtrj = mdt.fh.load_dtrj(infile)
     # Method 1: Censored counting.
     lts_cnt_cen_characs[sim_ix] = leap.lifetimes.count_method_state_average(
@@ -228,7 +231,10 @@ for sim_ix, Sim in enumerate(Sims.sims):
         + con
         + ".txt.gz"
     )
-    infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    try:
+        infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    except FileNotFoundError:
+        continue
     times, remain_prob_sim = np.loadtxt(
         infile, usecols=(0, 1), unpack=True, dtype=np.float32
     )
@@ -324,7 +330,6 @@ del (
     popt_conv_rp_brr_sim,
     perr_conv_rp_brr_sim,
 )
-remain_probs = np.asarray(remain_probs)
 
 
 print("Calculating renewal times from the Kaplan-Meier estimator...")
@@ -365,7 +370,10 @@ for sim_ix, Sim in enumerate(Sims.sims):
     file_suffix = (
         analysis + analysis_suffix + "_kaplan_meier_discard-neg-start.txt.gz"
     )
-    infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    try:
+        infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    except FileNotFoundError:
+        continue
     times, km_surv_func_sim, km_surv_func_var_sim = np.loadtxt(
         infile, unpack=True, dtype=np.float32
     )
@@ -466,7 +474,6 @@ del (
     popt_conv_km_brr_sim,
     perr_conv_km_brr_sim,
 )
-km_surv_funcs = np.asarray(km_surv_funcs)
 
 
 print("Creating output file(s)...")
@@ -757,9 +764,15 @@ with PdfPages(outfile_pdf) as pdf:
                 marker=marker_k,
                 alpha=leap.plot.ALPHA,
             )
-            ax_sm.plot(
-                xdata, lts_k, label=label_sm, color=color_sm, marker=marker_sm
-            )
+            valid = np.isfinite(lts_k)
+            if np.any(valid):
+                ax_sm.plot(
+                    xdata[valid],
+                    lts_k[valid],
+                    label=label_sm,
+                    color=color_sm,
+                    marker=marker_sm,
+                )
         # Method 4: Numerical integration of the remain probability.
         ax.errorbar(
             xdata,
@@ -894,13 +907,19 @@ with PdfPages(outfile_pdf) as pdf:
             marker=marker_cnt_cen,
             alpha=leap.plot.ALPHA,
         )
-        ax_sm.plot(
-            xdata,
-            lts_cnt_cen_characs[:, 11 + i] / divisor,
-            label=label_sm,
-            color=color_sm,
-            marker=marker_sm,
-        )
+        valid = np.isfinite(lts_cnt_cen_characs[:, 11 + i])
+        if np.any(valid):
+            if ylabel == "Renewal Events per Li Ion":
+                div = divisor[valid]
+            else:
+                div = divisor
+            ax_sm.plot(
+                xdata,
+                lts_cnt_cen_characs[:, 11 + i] / divisor,
+                label=label_sm,
+                color=color_sm,
+                marker=marker_sm,
+            )
         # Method 2: Uncensored counting.
         ax.plot(
             xdata,
@@ -1124,6 +1143,8 @@ with PdfPages(outfile_pdf) as pdf:
     ax.set_prop_cycle(color=colors)
     for sim_ix, Sim in enumerate(Sims.sims):
         rp = remain_probs[sim_ix]
+        if rp is None or not np.any(np.isfinite(rp)):
+            continue
         times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
         fit = mdt.func.kww(times_fit, *popt_rp_wbl[sim_ix])
         lines = ax.plot(
@@ -1161,6 +1182,8 @@ with PdfPages(outfile_pdf) as pdf:
     ax.set_prop_cycle(color=colors)
     for sim_ix, Sim in enumerate(Sims.sims):
         rp = remain_probs[sim_ix]
+        if rp is None or not np.any(np.isfinite(rp)):
+            continue
         times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
         fit = mdt.func.kww(times_fit, *popt_rp_wbl[sim_ix])
         res = rp[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]] - fit
@@ -1190,6 +1213,8 @@ with PdfPages(outfile_pdf) as pdf:
     ax.set_prop_cycle(color=colors)
     for sim_ix, Sim in enumerate(Sims.sims):
         km = km_surv_funcs[sim_ix]
+        if km is None or not np.any(np.isfinite(km)):
+            continue
         times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
         fit = mdt.func.kww(times_fit, *popt_km_wbl[sim_ix])
         lines = ax.plot(
@@ -1227,6 +1252,8 @@ with PdfPages(outfile_pdf) as pdf:
     ax.set_prop_cycle(color=colors)
     for sim_ix, Sim in enumerate(Sims.sims):
         km = km_surv_funcs[sim_ix]
+        if km is None or not np.any(np.isfinite(km)):
+            continue
         times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
         fit = mdt.func.kww(times_fit, *popt_km_wbl[sim_ix])
         res = km[fit_start_km[sim_ix] : fit_stop_km[sim_ix]] - fit
@@ -1256,6 +1283,8 @@ with PdfPages(outfile_pdf) as pdf:
     ax.set_prop_cycle(color=colors)
     for sim_ix, Sim in enumerate(Sims.sims):
         rp = remain_probs[sim_ix]
+        if rp is None or not np.any(np.isfinite(rp)):
+            continue
         times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
         fit = mdt.func.burr12_sf_alt(times_fit, *popt_rp_brr[sim_ix])
         lines = ax.plot(
@@ -1293,6 +1322,8 @@ with PdfPages(outfile_pdf) as pdf:
     ax.set_prop_cycle(color=colors)
     for sim_ix, Sim in enumerate(Sims.sims):
         rp = remain_probs[sim_ix]
+        if rp is None or not np.any(np.isfinite(rp)):
+            continue
         times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
         fit = mdt.func.burr12_sf_alt(times_fit, *popt_rp_brr[sim_ix])
         res = rp[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]] - fit
@@ -1322,6 +1353,8 @@ with PdfPages(outfile_pdf) as pdf:
     ax.set_prop_cycle(color=colors)
     for sim_ix, Sim in enumerate(Sims.sims):
         km = km_surv_funcs[sim_ix]
+        if km is None or not np.any(np.isfinite(km)):
+            continue
         times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
         fit = mdt.func.burr12_sf_alt(times_fit, *popt_km_brr[sim_ix])
         lines = ax.plot(
@@ -1359,6 +1392,8 @@ with PdfPages(outfile_pdf) as pdf:
     ax.set_prop_cycle(color=colors)
     for sim_ix, Sim in enumerate(Sims.sims):
         km = km_surv_funcs[sim_ix]
+        if km is None or not np.any(np.isfinite(km)):
+            continue
         times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
         fit = mdt.func.burr12_sf_alt(times_fit, *popt_km_brr[sim_ix])
         res = km[fit_start_km[sim_ix] : fit_stop_km[sim_ix]] - fit

--- a/scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_conc_dependence.py
@@ -1,0 +1,1387 @@
+#!/usr/bin/env python3
+
+
+"""
+Calculate and plot the renewal time for a given pair of compounds as
+function of the salt concentration.
+
+Calculate the time until the PEO chain (or more generally the ligand)
+that was bound the longest to the central ion detaches form the central
+ion.  The renewal time is calculated directly from the discrete
+trajectory (Method 1-3), from the corresponding remain probability
+function (Method 4-6) of from the corresponding Kaplan-Meier estimate of
+the survival function (Method 7-9).
+
+See
+:file:`scripts/bulk_and_walls/mdt/discrete-z/get_and_plot_bin_lifetimes.py`
+for more details about the calculation methods.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import MultipleLocator
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def equalize_xticks(ax):
+    """
+    Equalize x-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the x
+        ticks.
+    """
+    ax.xaxis.set_major_locator(MultipleLocator(0.1))
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Calculate and plot the renewal time for a given pair of compounds as"
+        " function of the salt concentration."
+    )
+)
+parser.add_argument(
+    "--sol",
+    type=str,
+    required=True,
+    choices=("g1", "g4", "peo63"),
+    help="Solvent name.",
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=True,
+    choices=("Li-ether", "Li-NTf2"),
+    help="Compounds for which to calculate the renewal times.",
+)
+parser.add_argument(
+    "--continuous",
+    required=False,
+    default=False,
+    action="store_true",
+    help="Use the 'continuous' definition of the remain probability function.",
+)
+parser.add_argument(
+    "--int-thresh",
+    type=float,
+    required=False,
+    default=0.01,
+    help=(
+        "Only calculate the renewal time by directly integrating the remain"
+        " probability if the remain probability decayed below the given"
+        " threshold.  Default:  %(default)s."
+    ),
+)
+parser.add_argument(
+    "--end-fit",
+    type=float,
+    required=False,
+    default=None,
+    help=(
+        "Last lag time (in ns) to include when fitting the remain probability."
+        "  Default:  %(default)s (this means end at 90%% of the lag times)."
+    ),
+)
+parser.add_argument(
+    "--stop-fit",
+    type=float,
+    required=False,
+    default=0.01,
+    help=(
+        "Stop fitting the remain probability as soon as it falls below this"
+        " threshold.  The fitting is stopped by whatever happens earlier:"
+        " --end-fit or --stop-fit.  Default: %(default)s"
+    ),
+)
+args = parser.parse_args()
+cmp1, cmp2 = args.cmp.split("-")
+
+if args.continuous:
+    con = "_continuous"
+else:
+    con = ""
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+analysis = "renewal_events"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+ana_path = os.path.join(analysis, analysis + analysis_suffix)
+tool = "mdt"  # Analysis software.
+outfile_base = (  # Output file name.
+    settings
+    + "_lintf2_"
+    + args.sol
+    + "_r_sc80_"
+    + analysis
+    + analysis_suffix
+    + con
+)
+outfile_txt = outfile_base + ".txt.gz"
+outfile_pdf = outfile_base + ".pdf"
+
+# Time conversion factor to convert trajectory steps to ns.
+time_conv = 2e-3
+# Number of moments to calculate.  For calculating the skewness, the 2nd
+# and 3rd (central) moments are required, for the kurtosis the 2nd and
+# 4th (central) moments are required.
+n_moms = 4
+# Fit method of `scipy.optimize.curve_fit` to use for all fits.
+fit_method = "trf"
+
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_" + args.sol + "_[0-9]*-[0-9]*_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, path_key="bulk", sort_key="Li_O_ratio"
+)
+
+
+print("Calculating renewal times directly from `dtrj`...")
+lts_cnt_cen_characs = np.full(
+    (Sims.n_sims, 10 + n_moms), np.nan, dtype=np.float32
+)
+lts_cnt_unc_characs = np.full_like(lts_cnt_cen_characs, np.nan)
+lts_k = np.full(Sims.n_sims, np.nan, dtype=np.float32)
+for sim_ix, Sim in enumerate(Sims.sims):
+    # Read discrete trajectory.
+    file_suffix = analysis + analysis_suffix + "_dtrj.npz"
+    infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    dtrj = mdt.fh.load_dtrj(infile)
+    # Method 1: Censored counting.
+    lts_cnt_cen_characs[sim_ix] = leap.lifetimes.count_method_state_average(
+        dtrj,
+        n_moms=n_moms,
+        time_conv=time_conv,
+        uncensored=False,
+        discard_neg_start=True,
+    )
+    # Method 2: Uncensored counting.
+    lts_cnt_unc_characs[sim_ix] = leap.lifetimes.count_method_state_average(
+        dtrj,
+        n_moms=n_moms,
+        time_conv=time_conv,
+        uncensored=True,
+        discard_neg_start=True,
+    )
+    # Method 3: Calculate the transition rate as the number of
+    # transitions leading out of a given state divided by the number of
+    # frames that compounds have spent in this state.  The average
+    # renewal time is calculated as the inverse transition rate.
+    rate = mdt.dtrj.trans_rate_tot(dtrj, discard_neg_start=True)
+    lts_k[sim_ix] = time_conv / rate
+del dtrj, rate
+
+
+print("Calculating renewal times from the remain probability...")
+times_prev = None
+remain_probs = [None for Sim in Sims.sims]
+
+lts_rp_int_characs = np.full(
+    (Sims.n_sims, 6 + n_moms), np.nan, dtype=np.float32
+)
+
+fit_start_rp = np.zeros(Sims.n_sims, dtype=np.uint32)
+fit_stop_rp = np.zeros_like(fit_start_rp)
+
+lts_rp_wbl_characs = np.full_like(lts_rp_int_characs, np.nan)
+lts_rp_wbl_fit_goodness = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
+popt_rp_wbl = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
+perr_rp_wbl = np.full_like(popt_rp_wbl, np.nan)
+tau0_rp_wbl = np.full(Sims.n_sims, np.nan, dtype=np.float32)
+tau0_rp_wbl_sd = np.full_like(tau0_rp_wbl, np.nan)
+beta_rp_wbl = np.full_like(tau0_rp_wbl, np.nan)
+beta_rp_wbl_sd = np.full_like(tau0_rp_wbl, np.nan)
+
+lts_rp_brr_characs = np.full_like(lts_rp_int_characs, np.nan)
+lts_rp_brr_fit_goodness = np.full_like(lts_rp_wbl_fit_goodness, np.nan)
+popt_rp_brr = np.full((Sims.n_sims, 3), np.nan, dtype=np.float32)
+perr_rp_brr = np.full_like(popt_rp_brr, np.nan)
+popt_conv_rp_brr = np.full_like(popt_rp_brr, np.nan)
+perr_conv_rp_brr = np.full_like(popt_rp_brr, np.nan)
+tau0_rp_brr = np.full(Sims.n_sims, np.nan, dtype=np.float32)
+tau0_rp_brr_sd = np.full_like(tau0_rp_brr, np.nan)
+beta_rp_brr = np.full_like(tau0_rp_brr, np.nan)
+beta_rp_brr_sd = np.full_like(tau0_rp_brr, np.nan)
+delta_rp_brr = np.full_like(tau0_rp_brr, np.nan)
+delta_rp_brr_sd = np.full_like(tau0_rp_brr, np.nan)
+
+for sim_ix, Sim in enumerate(Sims.sims):
+    # Read remain probability.
+    file_suffix = (
+        analysis
+        + analysis_suffix
+        + "_state_lifetime_discard-neg-start"
+        + con
+        + ".txt.gz"
+    )
+    infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    times, remain_prob_sim = np.loadtxt(
+        infile, usecols=(0, 1), unpack=True, dtype=np.float32
+    )
+    if times_prev is not None and not np.array_equal(times, times_prev):
+        # Saving the lag times for all simulations would be quite memory
+        # consuming.  Because in my case all simulations should have the
+        # same lag times, I am just saving one lag time array.
+        raise ValueError("The lag times of the different simulations differ")
+    times_prev = np.copy(times)
+    times *= time_conv
+    remain_probs[sim_ix] = remain_prob_sim
+    # Add an additional dimension to `remain_prob_sim`, because the used
+    # functions from `lintf2_ether_ana_postproc.lifetimes` expect an
+    # array of survival functions.
+    remain_prob_sim = remain_prob_sim.reshape(remain_prob_sim.shape + (1,))
+    # Method 4: Numerical integration of the remain probability.
+    lts_rp_int_characs_sim = leap.lifetimes.integral_method(
+        remain_prob_sim, times, n_moms=n_moms, int_thresh=args.int_thresh
+    )
+    lts_rp_int_characs[sim_ix] = np.squeeze(lts_rp_int_characs_sim)
+    # Get fit region for fitting methods.
+    fit_start_rp_sim, fit_stop_rp_sim = leap.lifetimes.get_fit_region(
+        remain_prob_sim, times, end_fit=args.end_fit, stop_fit=args.stop_fit
+    )
+    fit_start_rp[sim_ix] = fit_start_rp_sim[0]
+    fit_stop_rp[sim_ix] = fit_stop_rp_sim[0]
+    # Method 5: Weibull fit of the remain probability.
+    (
+        lts_rp_wbl_characs_sim,
+        lts_rp_wbl_fit_goodness_sim,
+        popt_rp_wbl_sim,
+        perr_rp_wbl_sim,
+    ) = leap.lifetimes.weibull_fit_method(
+        remain_prob_sim,
+        times,
+        fit_start=fit_start_rp_sim,
+        fit_stop=fit_stop_rp_sim,
+        n_moms=n_moms,
+        fit_method=fit_method,
+    )
+    lts_rp_wbl_characs[sim_ix] = np.squeeze(lts_rp_wbl_characs_sim)
+    lts_rp_wbl_fit_goodness[sim_ix] = np.squeeze(lts_rp_wbl_fit_goodness_sim)
+    popt_rp_wbl[sim_ix] = np.squeeze(popt_rp_wbl_sim)
+    perr_rp_wbl[sim_ix] = np.squeeze(perr_rp_wbl_sim)
+    tau0_rp_wbl[sim_ix], beta_rp_wbl[sim_ix] = popt_rp_wbl[sim_ix].T
+    tau0_rp_wbl_sd[sim_ix], beta_rp_wbl_sd[sim_ix] = perr_rp_wbl[sim_ix].T
+    # Method 6: Burr Type XII fit of the remain probability.
+    (
+        lts_rp_brr_characs_sim,
+        lts_rp_brr_fit_goodness_sim,
+        popt_rp_brr_sim,
+        perr_rp_brr_sim,
+        popt_conv_rp_brr_sim,
+        perr_conv_rp_brr_sim,
+    ) = leap.lifetimes.burr12_fit_method(
+        remain_prob_sim,
+        times,
+        fit_start=fit_start_rp_sim,
+        fit_stop=fit_stop_rp_sim,
+        n_moms=n_moms,
+        fit_method=fit_method,
+    )
+    lts_rp_brr_characs[sim_ix] = np.squeeze(lts_rp_brr_characs_sim)
+    lts_rp_brr_fit_goodness[sim_ix] = np.squeeze(lts_rp_brr_fit_goodness_sim)
+    popt_rp_brr[sim_ix] = np.squeeze(popt_rp_brr_sim)
+    perr_rp_brr[sim_ix] = np.squeeze(perr_rp_brr_sim)
+    popt_conv_rp_brr[sim_ix] = np.squeeze(popt_conv_rp_brr_sim)
+    perr_conv_rp_brr[sim_ix] = np.squeeze(perr_conv_rp_brr_sim)
+    (
+        tau0_rp_brr[sim_ix],
+        beta_rp_brr[sim_ix],
+        delta_rp_brr[sim_ix],
+    ) = popt_conv_rp_brr[sim_ix].T
+    (
+        tau0_rp_brr_sd[sim_ix],
+        beta_rp_brr_sd[sim_ix],
+        delta_rp_brr_sd[sim_ix],
+    ) = perr_conv_rp_brr[sim_ix].T
+del remain_prob_sim
+del lts_rp_int_characs_sim
+del fit_start_rp_sim, fit_stop_rp_sim
+del (
+    lts_rp_wbl_characs_sim,
+    lts_rp_wbl_fit_goodness_sim,
+    popt_rp_wbl_sim,
+    perr_rp_wbl_sim,
+)
+del (
+    lts_rp_brr_characs_sim,
+    lts_rp_brr_fit_goodness_sim,
+    popt_rp_brr_sim,
+    perr_rp_brr_sim,
+    popt_conv_rp_brr_sim,
+    perr_conv_rp_brr_sim,
+)
+remain_probs = np.asarray(remain_probs)
+
+
+print("Calculating renewal times from the Kaplan-Meier estimator...")
+times_prev = None
+km_surv_funcs = [None for Sim in Sims.sims]
+
+lts_km_int_characs = np.full(
+    (Sims.n_sims, 6 + n_moms), np.nan, dtype=np.float32
+)
+
+fit_start_km = np.zeros(Sims.n_sims, dtype=np.uint32)
+fit_stop_km = np.zeros_like(fit_start_km)
+
+lts_km_wbl_characs = np.full_like(lts_km_int_characs, np.nan)
+lts_km_wbl_fit_goodness = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
+popt_km_wbl = np.full((Sims.n_sims, 2), np.nan, dtype=np.float32)
+perr_km_wbl = np.full_like(popt_km_wbl, np.nan)
+tau0_km_wbl = np.full(Sims.n_sims, np.nan, dtype=np.float32)
+tau0_km_wbl_sd = np.full_like(tau0_km_wbl, np.nan)
+beta_km_wbl = np.full_like(tau0_km_wbl, np.nan)
+beta_km_wbl_sd = np.full_like(tau0_km_wbl, np.nan)
+
+lts_km_brr_characs = np.full_like(lts_km_int_characs, np.nan)
+lts_km_brr_fit_goodness = np.full_like(lts_km_wbl_fit_goodness, np.nan)
+popt_km_brr = np.full((Sims.n_sims, 3), np.nan, dtype=np.float32)
+perr_km_brr = np.full_like(popt_km_brr, np.nan)
+popt_conv_km_brr = np.full_like(popt_km_brr, np.nan)
+perr_conv_km_brr = np.full_like(popt_km_brr, np.nan)
+tau0_km_brr = np.full(Sims.n_sims, np.nan, dtype=np.float32)
+tau0_km_brr_sd = np.full_like(tau0_km_brr, np.nan)
+beta_km_brr = np.full_like(tau0_km_brr, np.nan)
+beta_km_brr_sd = np.full_like(tau0_km_brr, np.nan)
+delta_km_brr = np.full_like(tau0_km_brr, np.nan)
+delta_km_brr_sd = np.full_like(tau0_km_brr, np.nan)
+
+for sim_ix, Sim in enumerate(Sims.sims):
+    # Read Kaplan-Meier survival function.
+    file_suffix = (
+        analysis + analysis_suffix + "_kaplan_meier_discard-neg-start.txt.gz"
+    )
+    infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    times, km_surv_func_sim, km_surv_func_var_sim = np.loadtxt(
+        infile, unpack=True, dtype=np.float32
+    )
+    if times_prev is not None and not np.array_equal(times, times_prev):
+        # Saving the lag times for all simulations would be quite memory
+        # consuming.  Because in my case all simulations should have the
+        # same lag times, I am just saving one lag time array.
+        raise ValueError("The lag times of the different simulations differ")
+    times_prev = np.copy(times)
+    times *= time_conv
+    km_surv_funcs[sim_ix] = km_surv_func_sim
+    # Add an additional dimension to `km_surv_func_sim`, because the
+    # used functions from `lintf2_ether_ana_postproc.lifetimes` expect
+    # an array of survival functions.
+    km_surv_func_sim = km_surv_func_sim.reshape(km_surv_func_sim.shape + (1,))
+    km_surv_func_var_sim = km_surv_func_var_sim.reshape(
+        km_surv_func_var_sim.shape + (1,)
+    )
+    # Method 7: Numerical integration of the Kaplan-Meier estimator.
+    lts_km_int_characs_sim = leap.lifetimes.integral_method(
+        km_surv_func_sim, times, n_moms=n_moms, int_thresh=args.int_thresh
+    )
+    lts_km_int_characs[sim_ix] = np.squeeze(lts_km_int_characs_sim)
+    # Get fit region for fitting methods.
+    fit_start_km_sim, fit_stop_km_sim = leap.lifetimes.get_fit_region(
+        km_surv_func_sim, times, end_fit=args.end_fit, stop_fit=args.stop_fit
+    )
+    fit_start_km[sim_ix] = fit_start_km_sim[0]
+    fit_stop_km[sim_ix] = fit_stop_km_sim[0]
+    # Method 8: Weibull fit of the Kaplan-Meier estimator.
+    (
+        lts_km_wbl_characs_sim,
+        lts_km_wbl_fit_goodness_sim,
+        popt_km_wbl_sim,
+        perr_km_wbl_sim,
+    ) = leap.lifetimes.weibull_fit_method(
+        km_surv_func_sim,
+        times,
+        fit_start=fit_start_km_sim,
+        fit_stop=fit_stop_km_sim,
+        surv_funcs_var=km_surv_func_var_sim,
+        n_moms=n_moms,
+        fit_method=fit_method,
+    )
+    lts_km_wbl_characs[sim_ix] = np.squeeze(lts_km_wbl_characs_sim)
+    lts_km_wbl_fit_goodness[sim_ix] = np.squeeze(lts_km_wbl_fit_goodness_sim)
+    popt_km_wbl[sim_ix] = np.squeeze(popt_km_wbl_sim)
+    perr_km_wbl[sim_ix] = np.squeeze(perr_km_wbl_sim)
+    tau0_km_wbl[sim_ix], beta_km_wbl[sim_ix] = popt_km_wbl[sim_ix].T
+    tau0_km_wbl_sd[sim_ix], beta_km_wbl_sd[sim_ix] = perr_km_wbl[sim_ix].T
+    # Method 9: Burr Type XII fit of the Kaplan-Meier estimator.
+    (
+        lts_km_brr_characs_sim,
+        lts_km_brr_fit_goodness_sim,
+        popt_km_brr_sim,
+        perr_km_brr_sim,
+        popt_conv_km_brr_sim,
+        perr_conv_km_brr_sim,
+    ) = leap.lifetimes.burr12_fit_method(
+        km_surv_func_sim,
+        times,
+        fit_start=fit_start_km_sim,
+        fit_stop=fit_stop_km_sim,
+        surv_funcs_var=km_surv_func_var_sim,
+        n_moms=n_moms,
+        fit_method=fit_method,
+    )
+    lts_km_brr_characs[sim_ix] = np.squeeze(lts_km_brr_characs_sim)
+    lts_km_brr_fit_goodness[sim_ix] = np.squeeze(lts_km_brr_fit_goodness_sim)
+    popt_km_brr[sim_ix] = np.squeeze(popt_km_brr_sim)
+    perr_km_brr[sim_ix] = np.squeeze(perr_km_brr_sim)
+    popt_conv_km_brr[sim_ix] = np.squeeze(popt_conv_km_brr_sim)
+    perr_conv_km_brr[sim_ix] = np.squeeze(perr_conv_km_brr_sim)
+    (
+        tau0_km_brr[sim_ix],
+        beta_km_brr[sim_ix],
+        delta_km_brr[sim_ix],
+    ) = popt_conv_km_brr[sim_ix].T
+    (
+        tau0_km_brr_sd[sim_ix],
+        beta_km_brr_sd[sim_ix],
+        delta_km_brr_sd[sim_ix],
+    ) = perr_conv_km_brr[sim_ix].T
+del km_surv_func_sim, km_surv_func_var_sim
+del lts_km_int_characs_sim
+del fit_start_km_sim, fit_stop_km_sim
+del (
+    lts_km_wbl_characs_sim,
+    lts_km_wbl_fit_goodness_sim,
+    popt_km_wbl_sim,
+    perr_km_wbl_sim,
+)
+del (
+    lts_km_brr_characs_sim,
+    lts_km_brr_fit_goodness_sim,
+    popt_km_brr_sim,
+    perr_km_brr_sim,
+    popt_conv_km_brr_sim,
+    perr_conv_km_brr_sim,
+)
+km_surv_funcs = np.asarray(km_surv_funcs)
+
+
+print("Creating output file(s)...")
+xdata = Sims.Li_O_ratios
+data = np.column_stack(
+    [
+        xdata,  # 1
+        # Method 1: Censored counting.
+        lts_cnt_cen_characs,  # 2-15
+        # Method 2: Uncensored counting.
+        lts_cnt_unc_characs,  # 16-29
+        # Method 3: Inverse transition rate.
+        lts_k,  # 30
+        # Method 4: Numerical integration of the remain probability.
+        lts_rp_int_characs,  # 31-40
+        # Method 5: Weibull fit of the remain probability.
+        lts_rp_wbl_characs,  # 41-50
+        tau0_rp_wbl,  # 51
+        tau0_rp_wbl_sd,  # 52
+        beta_rp_wbl,  # 53
+        beta_rp_wbl_sd,  # 54
+        lts_rp_wbl_fit_goodness,  # 55-56
+        # Method 6: Burr Type XII fit of the remain probability.
+        lts_rp_brr_characs,  # 57-66
+        tau0_rp_brr,  # 67
+        tau0_rp_brr_sd,  # 68
+        beta_rp_brr,  # 69
+        beta_rp_brr_sd,  # 70
+        delta_rp_brr,  # 71
+        delta_rp_brr_sd,  # 72
+        lts_rp_brr_fit_goodness,  # 73-74
+        # Fit region for the remain probability.
+        fit_start_rp * time_conv,  # 75
+        (fit_stop_rp - 1) * time_conv,  # 76
+        # Method 7: Numerical integration of the Kaplan-Meier estimator.
+        lts_km_int_characs,  # 77-86
+        # Method 8: Weibull fit of the Kaplan-Meier estimator.
+        lts_km_wbl_characs,  # 87-96
+        tau0_km_wbl,  # 97
+        tau0_km_wbl_sd,  # 98
+        beta_km_wbl,  # 99
+        beta_km_wbl_sd,  # 100
+        lts_km_wbl_fit_goodness,  # 101-102
+        # Method 9: Burr Type XII fit of the Kaplan-Meier estimator.
+        lts_km_brr_characs,  # 103-112
+        tau0_km_brr,  # 113
+        tau0_km_brr_sd,  # 114
+        beta_km_brr,  # 115
+        beta_km_brr_sd,  # 116
+        delta_km_brr,  # 117
+        delta_km_brr_sd,  # 118
+        lts_km_brr_fit_goodness,  # 119-120
+        # Fit region for the Kaplan-Meier estimator.
+        fit_start_km * time_conv,  # 121
+        (fit_stop_km - 1) * time_conv,  # 122
+    ]
+)
+header = (
+    "{} renewal times.\n".format(args.cmp)
+    + "The renewal time is the average time after which the selection\n"
+    + "compound ('{}') that was continuously bound the longest to\n".format(
+        cmp2
+    )
+    + "a reference compound ('{}') dissociates from it.\n".format(cmp1)
+    + "\n"
+    + "No. of oxygens per PEO chain: {:d}\n".format(Sims.O_per_chain[0])
+    + "int_thresh = {:.4f}\n".format(args.int_thresh)
+    + "end_fit  = {}\n".format(args.end_fit)
+    + "stop_fit = {:.4f}\n".format(args.stop_fit)
+    + "\n"
+    + "\n"
+    + "The columns contain:\n"
+    + "  1 Lithium-to-ether-oxygen ratio\n"
+    + "\n"
+    + "Methods based on counting frames:\n"
+    + "  Method 1: Censored counting\n"
+    + "  2 Sample mean (1st raw moment) / ns\n"
+    + "  3 Uncertainty of the sample mean (standard error) / ns\n"
+    + "  4 Corrected sample standard deviation / ns\n"
+    + "  5 Corrected coefficient of variation\n"
+    + "  6 Unbiased sample skewness (Fisher)\n"
+    + "  7 Unbiased sample excess kurtosis (Fisher)\n"
+    + "  8 Sample median / ns\n"
+    + "  9 Non-parametric skewness\n"
+    + " 10 2nd raw moment (biased estimate) / ns^2\n"
+    + " 11 3rd raw moment (biased estimate) / ns^3\n"
+    + " 12 4th raw moment (biased estimate) / ns^4\n"
+    + " 13 Sample minimum / ns\n"
+    + " 14 Sample maximum / ns\n"
+    + " 15 Number of observations/samples\n"
+    + "\n"
+    + "  Method 2: Uncensored counting.\n"
+    + " 16-29 As Method 1\n"
+    + "\n"
+    + "  Method 3: Inverse transition rate\n"
+    + " 30 Mean renewal time / ns\n"
+    + "\n"
+    + "Methods based on the ACF:\n"
+    + "  Method 4: Numerical integration of the ACF\n"
+    + " 31 Mean renewal time (1st raw moment) / ns\n"
+    + " 32 Standard deviation / ns\n"
+    + " 33 Coefficient of variation"
+    + " 34 Skewness (Fisher)\n"
+    + " 35 Excess kurtosis (Fisher)\n"
+    + " 36 Median / ns\n"
+    + " 37 Non-parametric skewness\n"
+    + " 38 2nd raw moment / ns^2\n"
+    + " 39 3rd raw moment / ns^3\n"
+    + " 40 4th raw moment / ns^4\n"
+    + "\n"
+    + "  Method 5: Weibull fit of the ACF\n"
+    + " 41-50 As Method 4\n"
+    + " 51 Fit parameter tau0_wbl / ns\n"
+    + " 52 Standard deviation of tau0_wbl / ns\n"
+    + " 53 Fit parameter beta_wbl\n"
+    + " 54 Standard deviation of beta_wbl\n"
+    + " 55 Coefficient of determination of the fit (R^2 value)\n"
+    + " 56 Root-mean-square error (RMSE) of the fit\n"
+    + "\n"
+    + "  Method 6: Burr Type XII fit of the ACF\n"
+    + " 57-70 As Method 5\n"
+    + " 71 Fit parameter delta_brr\n"
+    + " 72 Standard deviation of delta_brr\n"
+    + " 73 Coefficient of determination of the fit (R^2 value)\n"
+    + " 74 Root-mean-square error (RMSE) of the fit\n"
+    + "\n"
+    + "  Fit region for all ACF fitting methods\n"
+    + " 75 Start of fit region (inclusive) / ns\n"
+    + " 76 End of fit region (inclusive) / ns\n"
+    + "\n"
+    + "Methods based on the Kaplan-Meier estimator:\n"
+    + "  Method 7: Numerical integration of the Kaplan-Meier estimator\n"
+    + " 77-86 As Method 4\n"
+    + "\n"
+    + "  Method 8: Weibull fit of the Kaplan-Meier estimator\n"
+    + " 87-102 As Method 5\n"
+    + "\n"
+    + "  Method 9: Burr Type XII fit of the Kaplan-Meier estimator\n"
+    + " 103-120 As Method 6\n"
+    + "\n"
+    + "  Fit region for all Kaplan-Meier estimator fitting methods\n"
+    + " 121 Start of fit region (inclusive) / ns\n"
+    + " 122 End of fit region (inclusive) / ns\n"
+    + "\n"
+    + "Column number:\n"
+)
+header += "{:>14d}".format(1)
+for i in range(2, data.shape[-1] + 1):
+    header += " {:>16d}".format(i)
+leap.io_handler.savetxt(outfile_txt, data, header=header)
+print("Created {}".format(outfile_txt))
+
+
+print("Creating plot(s)...")
+label_cnt_cen = "Cens."  # Count
+label_cnt_unc = "Uncens."  # Count
+label_k = "Rate"
+label_rp_int = "ACF Num"
+label_rp_wbl = "ACF Wbl"
+label_rp_brr = "ACF Burr"
+label_km_int = "KM Num"
+label_km_wbl = "KM Wbl"
+label_km_brr = "KM Burr"
+
+color_cnt_cen = "tab:orange"
+color_cnt_unc = "tab:red"
+color_k = "tab:brown"
+color_rp_int = "tab:purple"
+color_rp_wbl = "tab:blue"
+color_rp_brr = "tab:cyan"
+color_km_int = "goldenrod"
+color_km_wbl = "gold"
+color_km_brr = "yellow"
+
+marker_cnt_cen = "H"
+marker_cnt_unc = "h"
+marker_k = "p"
+marker_rp_int = "^"
+marker_rp_wbl = ">"
+marker_rp_brr = "<"
+marker_km_int = "s"
+marker_km_wbl = "D"
+marker_km_brr = "d"
+
+color_exp = "tab:green"
+linestyle_exp = "dashed"
+label_exp = "Exp. Dist."
+
+label_sm = None
+color_sm = None
+marker_sm = "o"
+
+ylabel_acf = "Autocorrelation Function"
+ylabel_km = "Kaplan-Meier Estimate"
+
+xlabel = r"Li-to-EO Ratio $r$"
+xlim = (0, 0.4 + 0.0125)
+legend_title = (
+    r"$"
+    + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp1]
+    + "-"
+    + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp2]
+    + r"$"
+    + "\n"
+    + r"$n_{EO} = %d$" % Sims.O_per_chain[0]
+)
+legend_title_sf = legend_title + "\n" + r"$r$"
+n_legend_col_sf = 1 + Sims.n_sims // (4 + 1)
+
+cmap = plt.get_cmap()
+c_vals = np.arange(Sims.n_sims)
+c_norm = max(1, Sims.n_sims - 1)
+c_vals_normed = c_vals / c_norm
+colors = cmap(c_vals_normed)
+
+mdt.fh.backup(outfile_pdf)
+with PdfPages(outfile_pdf) as pdf:
+    # Plot distribution characteristics vs. chain length.
+    ylabels = (
+        "Renewal Time / ns",
+        "Std. Dev. / ns",
+        "Coeff. of Variation",
+        "Skewness",
+        "Excess Kurtosis",
+        "Median / ns",
+        "Non-Parametric Skewness",
+    )
+    for i, ylabel in enumerate(ylabels):
+        # Figure containing all methods.
+        fig, ax = plt.subplots(clear=True)
+        # Figure containing only the finally chosen method.
+        fig_single_method, ax_sm = plt.subplots(clear=True)
+        if i == 0:
+            offset_i_cnt = 0
+        else:
+            offset_i_cnt = 1
+        if ylabel == "Coeff. of Variation":
+            y_exp = 1  # Coeff. of variation of exp. distribution.
+        elif ylabel == "Skewness":
+            y_exp = 2  # Skewness of exponential distribution.
+        elif ylabel == "Excess Kurtosis":
+            y_exp = 6  # Excess kurtosis of exponential distribution.
+        elif ylabel == "Non-Parametric Skewness":
+            y_exp = 1 - np.log(2)  # Non-param. skew. of exp. dist.
+        else:
+            y_exp = None
+        if y_exp is not None:
+            ax.axhline(
+                y=y_exp,
+                color=color_exp,
+                linestyle=linestyle_exp,
+                label=label_exp,
+            )
+            ax_sm.axhline(
+                y=y_exp,
+                color=color_exp,
+                linestyle=linestyle_exp,
+                label=label_exp,
+            )
+        # Method 1: Censored counting.
+        ax.errorbar(
+            xdata,
+            lts_cnt_cen_characs[:, i + offset_i_cnt],
+            yerr=lts_cnt_cen_characs[:, i + 1] if i == 0 else None,
+            label=label_cnt_cen,
+            color=color_cnt_cen,
+            marker=marker_cnt_cen,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 2: Uncensored counting.
+        ax.errorbar(
+            xdata,
+            lts_cnt_unc_characs[:, i + offset_i_cnt],
+            yerr=lts_cnt_unc_characs[:, i + 1] if i == 0 else None,
+            label=label_cnt_unc,
+            color=color_cnt_unc,
+            marker=marker_cnt_unc,
+            alpha=leap.plot.ALPHA,
+        )
+        if i == 0:
+            # Method 3: Inverse transition rate.
+            ax.errorbar(
+                xdata,
+                lts_k,
+                yerr=None,
+                label=label_k,
+                color=color_k,
+                marker=marker_k,
+                alpha=leap.plot.ALPHA,
+            )
+            ax_sm.plot(
+                xdata, lts_k, label=label_sm, color=color_sm, marker=marker_sm
+            )
+        # Method 4: Numerical integration of the remain probability.
+        ax.errorbar(
+            xdata,
+            lts_rp_int_characs[:, i],
+            yerr=None,
+            label=label_rp_int,
+            color=color_rp_int,
+            marker=marker_rp_int,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 5: Weibull fit of the remain probability.
+        ax.errorbar(
+            xdata,
+            lts_rp_wbl_characs[:, i],
+            yerr=None,
+            label=label_rp_wbl,
+            color=color_rp_wbl,
+            marker=marker_rp_wbl,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 6: Burr Type XII fit of the remain probability.
+        ax.errorbar(
+            xdata,
+            lts_rp_brr_characs[:, i],
+            yerr=None,
+            label=label_rp_brr,
+            color=color_rp_brr,
+            marker=marker_rp_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 7: Numerical integration of the KM estimator.
+        ax.errorbar(
+            xdata,
+            lts_km_int_characs[:, i],
+            yerr=None,
+            label=label_km_int,
+            color=color_km_int,
+            marker=marker_km_int,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 8: Weibull fit of the Kaplan-Meier estimator.
+        ax.errorbar(
+            xdata,
+            lts_km_wbl_characs[:, i],
+            yerr=None,
+            label=label_km_wbl,
+            color=color_km_wbl,
+            marker=marker_km_wbl,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 9: Burr Type XII fit of the Kaplan-Meier estimator.
+        ax.errorbar(
+            xdata,
+            lts_km_brr_characs[:, i],
+            yerr=None,
+            label=label_km_brr,
+            color=color_km_brr,
+            marker=marker_km_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        equalize_xticks(ax)
+        ylim = ax.get_ylim()
+        if ylim[0] < 0 and ylabel not in (
+            "Skewness",
+            "Excess Kurtosis",
+            "Non-Parametric Skewness",
+        ):
+            ax.set_ylim(0, ylim[1])
+        legend = ax.legend(
+            title=legend_title, ncol=3, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig(fig)
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax.relim()
+            ax.autoscale()
+            ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax.set_xlim(xlim)
+            pdf.savefig(fig)
+        plt.close(fig)
+        # The finally chosen method.
+        ax_sm.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        equalize_xticks(ax)
+        ylim = ax_sm.get_ylim()
+        if ylim[0] < 0 and ylabel not in (
+            "Skewness",
+            "Excess Kurtosis",
+            "Non-Parametric Skewness",
+        ):
+            ax_sm.set_ylim(0, ylim[1])
+        legend = ax_sm.legend(
+            title=legend_title, ncol=3, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig(fig_single_method)
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax_sm)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax_sm.relim()
+            ax_sm.autoscale()
+            ax_sm.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax_sm.set_xlim(xlim)
+            pdf.savefig(fig_single_method)
+        plt.close(fig_single_method)
+
+    # Plot min, max and number of samples for count methods.
+    ylabels = (
+        "Min. Renewal Time / ns",
+        "Max. Renewal Time / ns",
+        "No. of Renewal Events",
+        "Renewal Events per Li Ion",
+    )
+    for i, ylabel in enumerate(ylabels):
+        if ylabel == "Renewal Events per Li Ion":
+            divisor = Sims.res_nums["cation"]
+            i = 2
+        else:
+            divisor = 1
+        # Figure containing all methods.
+        fig, ax = plt.subplots(clear=True)
+        # Figure containing only the finally chosen method.
+        fig_single_method, ax_sm = plt.subplots(clear=True)
+        # Method 1: Censored counting.
+        ax.plot(
+            xdata,
+            lts_cnt_cen_characs[:, 11 + i] / divisor,
+            label=label_cnt_cen,
+            color=color_cnt_cen,
+            marker=marker_cnt_cen,
+            alpha=leap.plot.ALPHA,
+        )
+        ax_sm.plot(
+            xdata,
+            lts_cnt_cen_characs[:, 11 + i] / divisor,
+            label=label_sm,
+            color=color_sm,
+            marker=marker_sm,
+        )
+        # Method 2: Uncensored counting.
+        ax.plot(
+            xdata,
+            lts_cnt_unc_characs[:, 11 + i] / divisor,
+            label=label_cnt_unc,
+            color=color_cnt_unc,
+            marker=marker_cnt_unc,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        equalize_xticks(ax)
+        ylim = ax.get_ylim()
+        if ylim[0] < 0:
+            ax.set_ylim(0, ylim[1])
+        legend = ax.legend(
+            title=legend_title, ncol=2, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig(fig)
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax.relim()
+            ax.autoscale()
+            ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax.set_xlim(xlim)
+            pdf.savefig(fig)
+        plt.close(fig)
+        # The finally chosen method.
+        ax_sm.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        equalize_xticks(ax)
+        ylim = ax_sm.get_ylim()
+        if ylim[0] < 0:
+            ax_sm.set_ylim(0, ylim[1])
+        legend = ax_sm.legend(
+            title=legend_title, ncol=2, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig(fig_single_method)
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax_sm)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax_sm.relim()
+            ax_sm.autoscale()
+            ax_sm.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax_sm.set_xlim(xlim)
+            pdf.savefig(fig_single_method)
+        plt.close(fig_single_method)
+
+    # Plot fit parameters tau0, beta and delta.
+    ylabels = (
+        r"Fit Parameter $\tau_0$ / ns",
+        r"Fit Parameter $\beta$",
+        r"Fit Parameter $\delta$",
+    )
+    for i, ylabel in enumerate(ylabels):
+        fig, ax = plt.subplots(clear=True)
+        if i < 2:
+            # Method 5: Weibull fit of the remain probability.
+            ax.errorbar(
+                xdata,
+                popt_rp_wbl[:, i],
+                yerr=perr_rp_wbl[:, i],
+                label=label_rp_wbl,
+                color=color_rp_wbl,
+                marker=marker_rp_wbl,
+                alpha=leap.plot.ALPHA,
+            )
+        # Method 6: Burr Type XII fit of the remain probability.
+        ax.errorbar(
+            xdata,
+            popt_conv_rp_brr[:, i],
+            yerr=perr_conv_rp_brr[:, i],
+            label=label_rp_brr,
+            color=color_rp_brr,
+            marker=marker_rp_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        if i < 2:
+            # Method 8: Weibull fit of the Kaplan-Meier estimator.
+            ax.errorbar(
+                xdata,
+                popt_km_wbl[:, i],
+                yerr=perr_km_wbl[:, i],
+                label=label_km_wbl,
+                color=color_km_wbl,
+                marker=marker_km_wbl,
+                alpha=leap.plot.ALPHA,
+            )
+        # Method 9: Burr Type XII fit of the Kaplan-Meier estimator.
+        ax.errorbar(
+            xdata,
+            popt_conv_km_brr[:, i],
+            yerr=perr_conv_km_brr[:, i],
+            label=label_km_brr,
+            color=color_km_brr,
+            marker=marker_km_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        equalize_xticks(ax)
+        ylim = ax.get_ylim()
+        if ylim[0] < 0:
+            ax.set_ylim(0, ylim[1])
+        legend = ax.legend(
+            title=legend_title, ncol=2, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax.relim()
+            ax.autoscale()
+            ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax.set_xlim(xlim)
+            pdf.savefig()
+        plt.close()
+
+    # Plot goodness of fit quantities.
+    ylabels = (r"Coeff. of Determ. $R^2$", "RMSE")
+    for i, ylabel in enumerate(ylabels):
+        fig, ax = plt.subplots(clear=True)
+        # Method 5: Weibull fit of the remain probability.
+        ax.plot(
+            xdata,
+            lts_rp_wbl_fit_goodness[:, i],
+            label=label_rp_wbl,
+            color=color_rp_wbl,
+            marker=marker_rp_wbl,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 6: Burr Type XII fit of the remain probability.
+        ax.plot(
+            xdata,
+            lts_rp_brr_fit_goodness[:, i],
+            label=label_rp_brr,
+            color=color_rp_brr,
+            marker=marker_rp_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 8: Weibull fit of the Kaplan-Meier estimator.
+        ax.plot(
+            xdata,
+            lts_km_wbl_fit_goodness[:, i],
+            label=label_km_wbl,
+            color=color_km_wbl,
+            marker=marker_km_wbl,
+            alpha=leap.plot.ALPHA,
+        )
+        # Method 9: Burr Type XII fit of the Kaplan-Meier estimator.
+        ax.plot(
+            xdata,
+            lts_km_brr_fit_goodness[:, i],
+            label=label_km_brr,
+            color=color_km_brr,
+            marker=marker_km_brr,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+        equalize_xticks(ax)
+        ylim = ax.get_ylim()
+        if ylim[0] < 0:
+            ax.set_ylim(0, ylim[1])
+        legend = ax.legend(
+            title=legend_title, ncol=2, **mdtplt.LEGEND_KWARGS_XSMALL
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+        if np.any(np.greater(yd_min, 0)):
+            # Log scale y.
+            ax.relim()
+            ax.autoscale()
+            ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax.set_xlim(xlim)
+            pdf.savefig()
+        plt.close()
+
+    # Plot end of fit region.
+    ylabel = "End of Fit Region / ns"
+    fig, ax = plt.subplots(clear=True)
+    # Fit of remain probability.
+    ax.plot(
+        xdata,
+        (fit_stop_rp - 1) * time_conv,
+        label="ACF",
+        color=color_rp_wbl,
+        marker=marker_rp_wbl,
+    )
+    # Fit of Kaplan-Meier estimator.
+    ax.plot(
+        xdata,
+        (fit_stop_km - 1) * time_conv,
+        label="KM",
+        color=color_km_wbl,
+        marker=marker_km_wbl,
+    )
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+    equalize_xticks(ax)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(
+        title=legend_title, ncol=2, **mdtplt.LEGEND_KWARGS_XSMALL
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+    # Plot remain probabilities and Weibull fits.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        rp = remain_probs[sim_ix]
+        times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
+        fit = mdt.func.kww(times_fit, *popt_rp_wbl[sim_ix])
+        lines = ax.plot(
+            times,
+            rp,
+            label=r"$%.4f$" % Sim.Li_O_ratio,
+            linewidth=1,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.plot(
+            times_fit,
+            fit,
+            label="Wbl Fit" if sim_ix == Sims.n_sims - 1 else None,
+            linestyle="dashed",
+            color=lines[0].get_color(),
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel=ylabel_acf,
+        xlim=(times[1], times[-1]),
+        ylim=(0, 1),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+    # Plot Weibull fit residuals (remain probability).
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        rp = remain_probs[sim_ix]
+        times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
+        fit = mdt.func.kww(times_fit, *popt_rp_wbl[sim_ix])
+        res = rp[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]] - fit
+        ax.plot(
+            times_fit,
+            res,
+            label=r"$%.4f$" % Sim.Li_O_ratio,
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel="ACF Weibull Fit Res.",
+        xlim=(times[1], times[-1]),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot Kaplan-Meier estimates and Weibull fits.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        km = km_surv_funcs[sim_ix]
+        times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
+        fit = mdt.func.kww(times_fit, *popt_km_wbl[sim_ix])
+        lines = ax.plot(
+            times,
+            km,
+            label=r"$%.4f$" % Sim.Li_O_ratio,
+            linewidth=1,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.plot(
+            times_fit,
+            fit,
+            label="Wbl Fit" if sim_ix == Sims.n_sims - 1 else None,
+            linestyle="dashed",
+            color=lines[0].get_color(),
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel=ylabel_km,
+        xlim=(times[1], times[-1]),
+        ylim=(0, 1),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+    # Plot Weibull fit residuals (Kaplan-Meier).
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        km = km_surv_funcs[sim_ix]
+        times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
+        fit = mdt.func.kww(times_fit, *popt_km_wbl[sim_ix])
+        res = km[fit_start_km[sim_ix] : fit_stop_km[sim_ix]] - fit
+        ax.plot(
+            times_fit,
+            res,
+            label=r"$%.4f$" % Sim.Li_O_ratio,
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel="KM Weibull Fit Res.",
+        xlim=(times[1], times[-1]),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot remain probabilities and Burr fits.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        rp = remain_probs[sim_ix]
+        times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
+        fit = mdt.func.burr12_sf_alt(times_fit, *popt_rp_brr[sim_ix])
+        lines = ax.plot(
+            times,
+            rp,
+            label=r"$%.4f$" % Sim.Li_O_ratio,
+            linewidth=1,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.plot(
+            times_fit,
+            fit,
+            label="Burr Fit" if sim_ix == Sims.n_sims - 1 else None,
+            linestyle="dashed",
+            color=lines[0].get_color(),
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel=ylabel_acf,
+        xlim=(times[1], times[-1]),
+        ylim=(0, 1),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+    # Plot Burr fit residuals (remain probability).
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        rp = remain_probs[sim_ix]
+        times_fit = times[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]]
+        fit = mdt.func.burr12_sf_alt(times_fit, *popt_rp_brr[sim_ix])
+        res = rp[fit_start_rp[sim_ix] : fit_stop_rp[sim_ix]] - fit
+        ax.plot(
+            times_fit,
+            res,
+            label=r"$%.4f$" % Sim.Li_O_ratio,
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel="ACF Burr Fit Res.",
+        xlim=(times[1], times[-1]),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot Kaplan-Meier estimates and Burr fits for each state.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        km = km_surv_funcs[sim_ix]
+        times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
+        fit = mdt.func.burr12_sf_alt(times_fit, *popt_km_brr[sim_ix])
+        lines = ax.plot(
+            times,
+            km,
+            label=r"$%.4f$" % Sim.Li_O_ratio,
+            linewidth=1,
+            alpha=leap.plot.ALPHA,
+        )
+        ax.plot(
+            times_fit,
+            fit,
+            label="Burr Fit" if sim_ix == Sims.n_sims - 1 else None,
+            linestyle="dashed",
+            color=lines[0].get_color(),
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel=ylabel_km,
+        xlim=(times[1], times[-1]),
+        ylim=(0, 1),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+    # Plot Burr fit residuals (Kaplan-Meier) for each state.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for sim_ix, Sim in enumerate(Sims.sims):
+        km = km_surv_funcs[sim_ix]
+        times_fit = times[fit_start_km[sim_ix] : fit_stop_km[sim_ix]]
+        fit = mdt.func.burr12_sf_alt(times_fit, *popt_km_brr[sim_ix])
+        res = km[fit_start_km[sim_ix] : fit_stop_km[sim_ix]] - fit
+        ax.plot(
+            times_fit,
+            res,
+            label=r"$%.4f$" % Sim.Li_O_ratio,
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel="Time / ns",
+        ylabel="KM Burr Fit Res.",
+        xlim=(times[1], times[-1]),
+    )
+    legend = ax.legend(
+        title=legend_title_sf,
+        ncol=n_legend_col_sf,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile_pdf))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/renewal_events/plot_lifetime_autocorr_and_renewal_times_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events/plot_lifetime_autocorr_and_renewal_times_chain-length_dependence.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the coordination relaxation times and the renewal times as function
+of the PEO chain length in one plot.
+"""
+
+
+# Standard libraries
+import argparse
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the coordination relaxation times and the renewal times as"
+        " function of the PEO chain length in one plot."
+    )
+)
+args = parser.parse_args()
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+prefix = settings + "_lintf2_peoN_20-1_sc80_"
+path_to_acf = "../../lifetime_autocorr/chain-length_dependence/"
+infile_acf = (
+    path_to_acf
+    + prefix
+    + "lifetime_autocorr_combined_Li-OE_Li-OBT_Li-ether_Li-NTf2.txt.gz"
+)
+infile_renew_peo = prefix + "renewal_events_Li-ether_continuous.txt.gz"
+infile_renew_tfsi = prefix + "renewal_events_Li-NTf2_continuous.txt.gz"
+outfile = prefix + "lifetime_autocorr_and_renewal_times.pdf"
+
+
+print("Reading data...")
+acf_data = np.loadtxt(infile_acf, usecols=(0, 1, 2))
+rnw_peo_data = np.loadtxt(infile_renew_peo, usecols=(0, 29))
+rnw_tfsi_data = np.loadtxt(infile_renew_tfsi, usecols=(0, 29))
+
+
+print("Creating plot(s)...")
+xlabel = r"Ether Oxygens per Chain $n_{EO}$"
+xlim = (1, 200)
+legend_title = r"$r = 0.05$"
+labels = (
+    r"$Li-O_{PEO}$ Relaxation",
+    r"$Li-O_{TFSI}$ Relaxation",
+    r"$Li-PEO$ Renewal",
+    r"$Li-TFSI$ Renewal",
+)
+colors = ("tab:blue", "tab:cyan", "tab:red", "tab:orange")
+markers = ("^", "v", "s", "D")
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    fig, ax = plt.subplots(clear=True)
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-O_{PEO}$"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 1]
+        elif label.startswith(r"$Li-O_{TFSI}$"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 2]
+        elif label.startswith(r"$Li-PEO$"):
+            xdata, ydata = rnw_peo_data[:, 0], rnw_peo_data[:, 1]
+        elif label.startswith(r"$Li-TFSI$"):
+            xdata, ydata = rnw_tfsi_data[:, 0], rnw_tfsi_data[:, 1]
+        else:
+            raise ValueError("Unknown 'label': '{}'".format(label))
+        valid = np.isfinite(ydata)
+        xdata, ydata = xdata[valid], ydata[valid]
+        ax.plot(xdata, ydata, label=label, color=colors[i], marker=markers[i])
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel="Lifetime / ns", xlim=xlim)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title, **mdtplt.LEGEND_KWARGS_XSMALL)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/renewal_events/plot_lifetime_autocorr_and_renewal_times_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events/plot_lifetime_autocorr_and_renewal_times_conc_dependence.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the coordination relaxation times and the renewal times as function
+of the salt concentration in one plot.
+"""
+
+
+# Standard libraries
+import argparse
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import MultipleLocator
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def equalize_xticks(ax):
+    """
+    Equalize x-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the x
+        ticks.
+    """
+    ax.xaxis.set_major_locator(MultipleLocator(0.1))
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the coordination relaxation times and the renewal times as"
+        " function of the salt concentration in one plot."
+    )
+)
+parser.add_argument(
+    "--sol",
+    type=str,
+    required=True,
+    choices=("g1", "g4", "peo63"),
+    help="Solvent name.",
+)
+args = parser.parse_args()
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+prefix = settings + "_lintf2_" + args.sol + "_r_sc80_"
+path_to_acf = "../../lifetime_autocorr/conc_dependence/"
+infile_acf = (
+    path_to_acf
+    + prefix
+    + "lifetime_autocorr_combined_Li-OE_Li-OBT_Li-ether_Li-NTf2.txt.gz"
+)
+infile_renew_peo = prefix + "renewal_events_Li-ether_continuous.txt.gz"
+infile_renew_tfsi = prefix + "renewal_events_Li-NTf2_continuous.txt.gz"
+outfile = prefix + "lifetime_autocorr_and_renewal_times.pdf"
+
+
+print("Reading data...")
+acf_data = np.loadtxt(infile_acf, usecols=(0, 1, 2))
+rnw_peo_data = np.loadtxt(infile_renew_peo, usecols=(0, 29))
+rnw_tfsi_data = np.loadtxt(infile_renew_tfsi, usecols=(0, 29))
+
+
+print("Creating plot(s)...")
+xlabel = r"Li-to-EO Ratio $r$"
+xlim = (0, 0.4 + 0.0125)
+if args.sol == "g1":
+    legend_title = r"$n_{EO} = 2$"
+elif args.sol == "g4":
+    legend_title = r"$n_{EO} = 5$"
+elif args.sol == "peo63":
+    legend_title = r"$n_{EO} = 64$"
+else:
+    raise ValueError("Unknown --sol: {}".format(args.sol))
+labels = (
+    r"$Li-O_{PEO}$ Relaxation",
+    r"$Li-O_{TFSI}$ Relaxation",
+    r"$Li-PEO$ Renewal",
+    r"$Li-TFSI$ Renewal",
+)
+colors = ("tab:blue", "tab:cyan", "tab:red", "tab:orange")
+markers = ("^", "v", "s", "D")
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    fig, ax = plt.subplots(clear=True)
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-O_{PEO}$"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 1]
+        elif label.startswith(r"$Li-O_{TFSI}$"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 2]
+        elif label.startswith(r"$Li-PEO$"):
+            xdata, ydata = rnw_peo_data[:, 0], rnw_peo_data[:, 1]
+        elif label.startswith(r"$Li-TFSI$"):
+            xdata, ydata = rnw_tfsi_data[:, 0], rnw_tfsi_data[:, 1]
+        else:
+            raise ValueError("Unknown 'label': '{}'".format(label))
+        # valid = np.isfinite(ydata)
+        # xdata, ydata = xdata[valid], ydata[valid]
+        ax.plot(xdata, ydata, label=label, color=colors[i], marker=markers[i])
+    ax.set(xlabel=xlabel, ylabel="Lifetime / ns", xlim=xlim)
+    equalize_xticks(ax)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title, **mdtplt.LEGEND_KWARGS_XSMALL)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/src/lintf2_ether_ana_postproc/lifetimes.py
+++ b/src/lintf2_ether_ana_postproc/lifetimes.py
@@ -77,6 +77,52 @@ def dist_characs(a, axis=-1, n_moms=4):
     return characs
 
 
+def count_method_state_average(dtrj, n_moms=4, time_conv=1, **kwargs):
+    """
+    Estimate characteristics of the underlying lifetime distribution
+    from a sample of lifetimes.
+
+    Take a discrete trajectory and count the number of frames that a
+    given compound stays in a given state.  Estimate characteristics of
+    the underlying lifetime distribution from the obtained sample.
+
+    The difference to
+    :func:`lintf2_ether_ana_postproc.lifetimes.count_method` is that
+    this function returns a mean lifetime averaged over all states.
+
+    Parameters
+    ----------
+    dtrj : array_like
+        The discrete trajectory.  Array of shape ``(n, f)``, where ``n``
+        is the number of compounds and ``f`` is the number of frames.
+        The shape can also be ``(f,)``, in which case the array is
+        expanded to shape ``(1, f)``.   The elements of `dtrj` are
+        interpreted as the indices of the states in which a given
+        compound is at a given frame.
+    n_moms : int, optional
+        Number of raw moments to calculate.
+    time_conv : scalar, optional
+        Time conversion factor.  All lifetimes are multiplied by this
+        factor.
+    kwargs : dict, optional
+        Keyword arguments to parse to :func:`mdtools.dtrj.lifetimes`.
+        See there for possible choices.  Not allowed are keyword
+        arguments that change the number of return values of
+        :func:`mdtools.dtrj.lifetimes`.
+
+    Returns
+    -------
+    characs : numpy.ndarray
+        Estimated distribution characteristics.  See
+        :func:`lintf2_ether_ana_postproc.lifetimes.dist_characs` for
+        more details.
+    """
+    lts = mdt.dtrj.lifetimes(dtrj, **kwargs)
+    lts = lts * time_conv
+    characs = leap.lifetimes.dist_characs(lts, n_moms=n_moms)
+    return characs
+
+
 def count_method(
     dtrj, uncensored=False, n_moms=4, time_conv=1, states_check=None
 ):
@@ -87,6 +133,11 @@ def count_method(
     Take a discrete trajectory and count the number of frames that a
     given compound stays in a given state.  Estimate characteristics of
     the underlying lifetime distribution from the obtained sample.
+
+    The difference to
+    :func:`lintf2_ether_ana_postproc.lifetimes.count_method_state_average`
+    is that this function returns a mean lifetime for each individual
+    state.
 
     Parameters
     ----------
@@ -117,7 +168,8 @@ def count_method(
     -------
     characs : numpy.ndarray
         Estimated distribution characteristics.  See
-        :func:`dist_characs` for more details.
+        :func:`lintf2_ether_ana_postproc.lifetimes.dist_characs` for
+        more details.
     states : numpy.ndarray
         The state indices.
 

--- a/src/lintf2_ether_ana_postproc/lifetimes.py
+++ b/src/lintf2_ether_ana_postproc/lifetimes.py
@@ -365,8 +365,8 @@ def kurtosis(mu2, mu4):
     return np.divide(mu4, np.power(mu2, 2)) - 3
 
 
-def integral_method_single(surv_func, times, n_moms=4, int_thresh=0.01):
-    """
+def integral_method(surv_funcs, times, n_moms=4, int_thresh=0.01):
+    r"""
     Estimate characteristics of the underlying lifetime distribution by
     numerically integrating/evaluating the survival function.
 
@@ -378,15 +378,13 @@ def integral_method_single(surv_func, times, n_moms=4, int_thresh=0.01):
     moments.  The median is estimated as the lag time at which the
     survival function decays below 0.5.
 
-    The difference to
-    :func:`lintf2_ether_ana_postproc.lifetimes.integral_method` is that
-    this function takes a single survival function.
-
     Parameters
     ----------
-    surv_func : array_like
-        Array of shape ``(t,)``, where ``t`` is the number of lag times,
-        containing the values of the survival function.
+    surv_funcs : array_like
+        Array of shape ``(t, s)`` where ``t`` is the number of lag times
+        and ``s`` is the number of different states.  The ij-th element
+        of `surv_funcs` is the value of the survival function of state
+        j after a lag time of i frames.
     times : array_like
         Array of shape ``(t,)`` containing the corresponding lag times.
     n_moms : int, optional
@@ -415,93 +413,6 @@ def integral_method_single(surv_func, times, n_moms=4, int_thresh=0.01):
         The number of calculated raw moments depends on `n_moms`.  The
         first raw moment (mean) is always calculated.
     """
-    surv_func = np.asarray(surv_func)
-    times = np.asarray(times)
-    if surv_func.ndim != 1:
-        raise ValueError(
-            "`surv_func` must be 1-dimensional but is"
-            " {}-dimensional".format(surv_func.ndim)
-        )
-    if times.shape != surv_func.shape[:1]:
-        raise ValueError(
-            "`times.shape` ({}) != `surv_func.shape[:1]`"
-            " ({})".format(times.shape, surv_func.shape[:1])
-        )
-    if n_moms < 1:
-        raise ValueError(
-            "`n_moms` ({}) must be greater than zero".format(n_moms)
-        )
-
-    raw_moms = np.full(n_moms, np.nan, dtype=np.float64)
-    cen_moms = np.full_like(raw_moms, np.nan)
-    if np.any(surv_func <= int_thresh):
-        # Only calculate the moments by numerical integration if the
-        # survival function decays below the given threshold.
-        for n in range(len(raw_moms)):
-            raw_moms[n] = leap.lifetimes.raw_moment_integrate(
-                sf=surv_func, x=times, n=n + 1
-            )
-            cen_moms[n] = mdt.stats.moment_raw2cen(raw_moms[: n + 1])
-    skew = leap.lifetimes.skewness(mu2=cen_moms[1], mu3=cen_moms[2])
-    kurt = leap.lifetimes.kurtosis(mu2=cen_moms[1], mu4=cen_moms[3])
-    std = np.sqrt(cen_moms[1])
-    cv = std / raw_moms[0]
-    median = leap.lifetimes.cross(y=0.5, x=times, f=surv_func)
-    skew_non_param = np.divide((raw_moms[0] - median), std)
-    characs = np.array(
-        [
-            raw_moms[0],  # Mean.
-            std,  # Standard deviation.
-            cv,  # Coefficient of variation.
-            skew,  # Skewness (Fisher).
-            kurt,  # Excess kurtosis (Fisher).
-            median,  # Median
-            skew_non_param,  # Non-parametric skewness.
-            *raw_moms[1:],  # 2nd to `n_moms`-th raw moment.
-        ]
-    )
-    return characs
-
-
-def integral_method(surv_funcs, times, n_moms=4, int_thresh=0.01):
-    """
-    Estimate characteristics of the underlying lifetime distribution by
-    numerically integrating/evaluating the survival function.
-
-    Take a survival function and calculate the raw moments of the
-    underlying lifetime distribution by numerically integrating the
-    survival function according to the alternative expectation formula
-    (see :func:`raw_moment_integrate` for more details).  The standard
-    deviation, skewness and excess kurtosis are calculated from the raw
-    moments.  The median is estimated as the lag time at which the
-    survival function decays below 0.5.
-
-    The difference to
-    :func:`lintf2_ether_ana_postproc.lifetimes.integral_method_single`
-    is that this function takes an array of survival functions.
-
-    Parameters
-    ----------
-    surv_funcs : array_like
-        Array of shape ``(t, s)`` where ``t`` is the number of lag times
-        and ``s`` is the number of different states.  The ij-th element
-        of `surv_funcs` is the value of the survival function of state
-        j after a lag time of i frames.
-    times : array_like
-        Array of shape ``(t,)`` containing the corresponding lag times.
-    n_moms : int, optional
-        Number of moments to calculate.  Must be greater than zero.
-    int_thresh : float, optional
-        Only calculate raw moments by numerical integration if the
-        survival function decays below the given threshold.
-
-    Returns
-    -------
-    characs : numpy.ndarray
-        Estimated distribution characteristics.  See
-        :func:`lintf2_ether_ana_postproc.lifetimes.integral_method_single`
-        for more details.
-    """
     surv_funcs = np.asarray(surv_funcs)
     times = np.asarray(times)
     if surv_funcs.ndim != 2:
@@ -522,8 +433,33 @@ def integral_method(surv_funcs, times, n_moms=4, int_thresh=0.01):
     n_frames, n_states = surv_funcs.shape
     characs = np.full((n_states, 6 + n_moms), np.nan, dtype=np.float64)
     for i, sf in enumerate(surv_funcs.T):
-        characs[i] = integral_method_single(
-            sf, times, n_moms=n_moms, int_thresh=int_thresh
+        raw_moms = np.full(n_moms, np.nan, dtype=np.float64)
+        cen_moms = np.full_like(raw_moms, np.nan)
+        if np.any(sf <= int_thresh):
+            # Only calculate the moments by numerical integration if the
+            # survival function decays below the given threshold.
+            for n in range(len(raw_moms)):
+                raw_moms[n] = leap.lifetimes.raw_moment_integrate(
+                    sf=sf, x=times, n=n + 1
+                )
+                cen_moms[n] = mdt.stats.moment_raw2cen(raw_moms[: n + 1])
+        skew = leap.lifetimes.skewness(mu2=cen_moms[1], mu3=cen_moms[2])
+        kurt = leap.lifetimes.kurtosis(mu2=cen_moms[1], mu4=cen_moms[3])
+        std = np.sqrt(cen_moms[1])
+        cv = std / raw_moms[0]
+        median = leap.lifetimes.cross(y=0.5, x=times, f=sf)
+        skew_non_param = np.divide((raw_moms[0] - median), std)
+        characs[i] = np.array(
+            [
+                raw_moms[0],  # Mean.
+                std,  # Standard deviation.
+                cv,  # Coefficient of variation.
+                skew,  # Skewness (Fisher).
+                kurt,  # Excess kurtosis (Fisher).
+                median,  # Median
+                skew_non_param,  # Non-parametric skewness.
+                *raw_moms[1:],  # 2nd to `n_moms`-th raw moment.
+            ]
         )
     return characs
 

--- a/src/lintf2_ether_ana_postproc/lifetimes.py
+++ b/src/lintf2_ether_ana_postproc/lifetimes.py
@@ -123,9 +123,7 @@ def count_method_state_average(dtrj, n_moms=4, time_conv=1, **kwargs):
     return characs
 
 
-def count_method(
-    dtrj, uncensored=False, n_moms=4, time_conv=1, states_check=None
-):
+def count_method(dtrj, n_moms=4, time_conv=1, states_check=None, **kwargs):
     """
     Estimate characteristics of the underlying lifetime distribution
     from a sample of lifetimes.
@@ -148,12 +146,6 @@ def count_method(
         expanded to shape ``(1, f)``.   The elements of `dtrj` are
         interpreted as the indices of the states in which a given
         compound is at a given frame.
-    uncensored : bool, optional
-        If ``True`` only take into account uncensored states, i.e.
-        states whose start and end lie within the trajectory.  In other
-        words, discard the truncated (censored) states at the beginning
-        and end of the trajectory.  For these states the start/end time
-        is unknown.
     n_moms : int, optional
         Number of raw moments to calculate.
     time_conv : scalar, optional
@@ -163,6 +155,11 @@ def count_method(
         Expected state indices.  If provided, the state indices in the
         discrete trajectory are checked against the provided state
         indices.
+    kwargs : dict, optional
+        Keyword arguments to parse to :func:`mdtools.dtrj.lifetimes`.
+        See there for possible choices.  Not allowed are keyword
+        arguments that change the number of return values of
+        :func:`mdtools.dtrj.lifetimes`.
 
     Returns
     -------
@@ -179,8 +176,9 @@ def count_method(
         If the state indices in the given discrete trajectory are not
         contained in the given array of state indices.
     """
+    uncensored = kwargs.get("uncensored", False)
     lts_per_state, states = mdt.dtrj.lifetimes_per_state(
-        dtrj, uncensored=uncensored, return_states=True
+        dtrj, return_states=True, **kwargs
     )
     lts_per_state = [lts * time_conv for lts in lts_per_state]
     if states_check is not None and not np.all(np.isin(states, states_check)):


### PR DESCRIPTION
# New Scripts to Extract and Plot Renewal Times

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [x] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

### New Features

* New Python script `scripts/bulk_and_walls/mdt/renewal_events/plot_lifetime_autocorr_and_renewal_times_conc_dependence.py`: that plots the coordination relaxation times and the renewal times as function of the salt concentration in one plot.
* New Python script `scripts/bulk_and_walls/mdt/renewal_events/plot_lifetime_autocorr_and_renewal_times_chain-length_dependence.py` that plots the coordination relaxation times and the renewal times as function of the PEO chain length in one plot.
* New Python script `scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_conc_dependence.py` that calculates and plots the renewal time for a given pair of compounds as function of the salt concentration.
* New Python script `scripts/bulk_and_walls/mdt/renewal_events/get_and_plot_bulk_renewal_times_chain-length_dependence.py` that calculates and plots the renewal time for a given pair of compounds as function of the PEO chain length.
* New Function `lintf2_ether_ana_postproc.lifetimes.count_method_state_average` that takes a discrete trajectory, counts the number of frames that a given compound stays in a given state and estimates characteristics of the underlying lifetime distribution from the obtained sample.

### Code Refactoring

* Python script `plot_lifetime_autocorr_combined_conc_dependence.py`: Write the average coordination relaxation times to file.
* Python script `plot_lifetime_autocorr_combined_chain-length_dependence.py`: Write the average coordination relaxation times to file.
* Python script `plot_diff_coeff_chain-length_dependence*.py`: Add/Update Legend Title.
* Function `lintf2_ether_ana_postproc.lifetimes.count_method`: Replace the argument `uncensored` by a `**kwargs` argument that is parsed to the function `mdtools.dtrj.lifetimes_per_state`.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] The CI workflow is passing.
