### PR TITLE
Lifetime Autocorrelation Functions: Correct Terminology

### DIFF
--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_chain-length_dependence.py
@@ -190,7 +190,7 @@ with PdfPages(outfile) as pdf:
     fig, ax = plt.subplots(clear=True)
     ax.plot(Sims.O_per_chain, lifetimes, marker="o")
     ax.set_xscale("log", base=10, subs=np.arange(2, 10))
-    ax.set(xlabel=xlabel, ylabel="Relaxation Time / ns", xlim=xlim)
+    ax.set(xlabel=xlabel, ylabel="Correlation Time / ns", xlim=xlim)
     ylim = ax.get_ylim()
     if ylim[0] < 0:
         ax.set_ylim(0, ylim[1])

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_chain-length_dependence.py
@@ -202,7 +202,7 @@ with PdfPages(outfile_pdf) as pdf:
             marker=markers[cmp_ix],
         )
     ax.set_xscale("log", base=10, subs=np.arange(2, 10))
-    ax.set(xlabel=xlabel, ylabel="Relaxation Time / ns", xlim=xlim)
+    ax.set(xlabel=xlabel, ylabel="Correlation Time / ns", xlim=xlim)
     ylim = ax.get_ylim()
     if ylim[0] < 0:
         ax.set_ylim(0, ylim[1])
@@ -223,16 +223,16 @@ with PdfPages(outfile_pdf) as pdf:
 
 print("Creating output file(s)...")
 header = (
-    "Coordination relaxation times.\n"
+    "Coordination correlation times.\n"
     + "\n"
-    + "Average coordination relaxation times are calculated by numerical\n"
+    + "Average coordination correlation times are calculated by numerical\n"
     + "integration of the lifetime autocorrelation function."
     + "\n\n"
     + "The columns contain:\n"
     + " 1 Number of ether oxygens per PEO chain\n"
 )
 for col, cmp in enumerate(args.cmps, start=2):
-    header += " {:d} {:s} relaxation time / ns\n".format(col, cmp)
+    header += " {:d} {:s} correlation time / ns\n".format(col, cmp)
 data = np.column_stack([Sims.O_per_chain, lifetimes.T])
 leap.io_handler.savetxt(outfile_txt, data, header=header)
 print("Created {}".format(outfile_txt))

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_combined_conc_dependence.py
@@ -211,7 +211,7 @@ with PdfPages(outfile_pdf) as pdf:
             label=cmp_label,
             marker=markers[cmp_ix],
         )
-    ax.set(xlabel=xlabel, ylabel="Relaxation Time / ns", xlim=xlim)
+    ax.set(xlabel=xlabel, ylabel="Correlation Time / ns", xlim=xlim)
     equalize_xticks(ax)
     ylim = ax.get_ylim()
     if ylim[0] < 0:
@@ -233,16 +233,16 @@ with PdfPages(outfile_pdf) as pdf:
 
 print("Creating output file(s)...")
 header = (
-    "Coordination relaxation times.\n"
+    "Coordination correlation times.\n"
     + "\n"
-    + "Average coordination relaxation times are calculated by numerical\n"
+    + "Average coordination correlation times are calculated by numerical\n"
     + "integration of the lifetime autocorrelation function."
     + "\n\n"
     + "The columns contain:\n"
     + " 1 Number of ether oxygens per PEO chain\n"
 )
 for col, cmp in enumerate(args.cmps, start=2):
-    header += " {:d} {:s} relaxation time / ns\n".format(col, cmp)
+    header += " {:d} {:s} correlation time / ns\n".format(col, cmp)
 data = np.column_stack([Sims.Li_O_ratios, lifetimes.T])
 leap.io_handler.savetxt(outfile_txt, data, header=header)
 print("Created {}".format(outfile_txt))

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr/plot_lifetime_autocorr_conc_dependence.py
@@ -170,7 +170,7 @@ with PdfPages(outfile) as pdf:
     xlim = (0, 0.4 + 0.0125)
     fig, ax = plt.subplots(clear=True)
     ax.plot(Sims.Li_O_ratios, lifetimes, marker="o")
-    ax.set(xlabel=xlabel, ylabel="Relaxation Time / ns", xlim=xlim)
+    ax.set(xlabel=xlabel, ylabel="Correlation Time / ns", xlim=xlim)
     equalize_xticks(ax)
     ylim = ax.get_ylim()
     if ylim[0] < 0:

--- a/scripts/bulk_and_walls/mdt/renewal_events/plot_lifetime_autocorr_and_renewal_times_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events/plot_lifetime_autocorr_and_renewal_times_chain-length_dependence.py
@@ -2,8 +2,8 @@
 
 
 """
-Plot the coordination relaxation times and the renewal times as function
-of the PEO chain length in one plot.
+Plot the coordination correlation times and the renewal times as
+function of the PEO chain length in one plot.
 """
 
 
@@ -24,7 +24,7 @@ import lintf2_ether_ana_postproc as leap
 # Input parameters.
 parser = argparse.ArgumentParser(
     description=(
-        "Plot the coordination relaxation times and the renewal times as"
+        "Plot the coordination correlation times and the renewal times as"
         " function of the PEO chain length in one plot."
     )
 )
@@ -54,10 +54,10 @@ xlabel = r"Ether Oxygens per Chain $n_{EO}$"
 xlim = (1, 200)
 legend_title = r"$r = 0.05$"
 labels = (
-    r"$Li-O_{PEO}$ Relaxation",
-    r"$Li-O_{TFSI}$ Relaxation",
-    r"$Li-PEO$ Relaxation",
-    r"$Li-TFSI$ Relaxation",
+    r"$Li-O_{PEO}$ Correlation",
+    r"$Li-O_{TFSI}$ Correlation",
+    r"$Li-PEO$ Correlation",
+    r"$Li-TFSI$ Correlation",
     r"$Li-PEO$ Renewal",
     # r"$Li-TFSI$ Renewal",
 )
@@ -69,13 +69,13 @@ mdt.fh.backup(outfile)
 with PdfPages(outfile) as pdf:
     fig, ax = plt.subplots(clear=True)
     for i, label in enumerate(labels):
-        if label.startswith(r"$Li-O_{PEO}$ Relaxation"):
+        if label.startswith(r"$Li-O_{PEO}$ Correlation"):
             xdata, ydata = acf_data[:, 0], acf_data[:, 1]
-        elif label.startswith(r"$Li-O_{TFSI}$ Relaxation"):
+        elif label.startswith(r"$Li-O_{TFSI}$ Correlation"):
             xdata, ydata = acf_data[:, 0], acf_data[:, 2]
-        elif label.startswith(r"$Li-PEO$ Relaxation"):
+        elif label.startswith(r"$Li-PEO$ Correlation"):
             xdata, ydata = acf_data[:, 0], acf_data[:, 3]
-        elif label.startswith(r"$Li-TFSI$ Relaxation"):
+        elif label.startswith(r"$Li-TFSI$ Correlation"):
             xdata, ydata = acf_data[:, 0], acf_data[:, 4]
         elif label.startswith(r"$Li-PEO$ Renewal"):
             xdata, ydata = rnw_peo_data[:, 0], rnw_peo_data[:, 1]

--- a/scripts/bulk_and_walls/mdt/renewal_events/plot_lifetime_autocorr_and_renewal_times_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events/plot_lifetime_autocorr_and_renewal_times_conc_dependence.py
@@ -2,8 +2,8 @@
 
 
 """
-Plot the coordination relaxation times and the renewal times as function
-of the salt concentration in one plot.
+Plot the coordination correlation times and the renewal times as
+function of the salt concentration in one plot.
 """
 
 
@@ -38,7 +38,7 @@ def equalize_xticks(ax):
 # Input parameters.
 parser = argparse.ArgumentParser(
     description=(
-        "Plot the coordination relaxation times and the renewal times as"
+        "Plot the coordination correlation times and the renewal times as"
         " function of the salt concentration in one plot."
     )
 )
@@ -82,10 +82,10 @@ elif args.sol == "peo63":
 else:
     raise ValueError("Unknown --sol: {}".format(args.sol))
 labels = (
-    r"$Li-O_{PEO}$ Relaxation",
-    r"$Li-O_{TFSI}$ Relaxation",
-    r"$Li-PEO$ Relaxation",
-    r"$Li-TFSI$ Relaxation",
+    r"$Li-O_{PEO}$ Correlation",
+    r"$Li-O_{TFSI}$ Correlation",
+    r"$Li-PEO$ Correlation",
+    r"$Li-TFSI$ Correlation",
     r"$Li-PEO$ Renewal",
     # r"$Li-TFSI$ Renewal",
 )
@@ -97,13 +97,13 @@ mdt.fh.backup(outfile)
 with PdfPages(outfile) as pdf:
     fig, ax = plt.subplots(clear=True)
     for i, label in enumerate(labels):
-        if label.startswith(r"$Li-O_{PEO}$ Relaxation"):
+        if label.startswith(r"$Li-O_{PEO}$ Correlation"):
             xdata, ydata = acf_data[:, 0], acf_data[:, 1]
-        elif label.startswith(r"$Li-O_{TFSI}$ Relaxation"):
+        elif label.startswith(r"$Li-O_{TFSI}$ Correlation"):
             xdata, ydata = acf_data[:, 0], acf_data[:, 2]
-        elif label.startswith(r"$Li-PEO$ Relaxation"):
+        elif label.startswith(r"$Li-PEO$ Correlation"):
             xdata, ydata = acf_data[:, 0], acf_data[:, 3]
-        elif label.startswith(r"$Li-TFSI$ Relaxation"):
+        elif label.startswith(r"$Li-TFSI$ Correlation"):
             xdata, ydata = acf_data[:, 0], acf_data[:, 4]
         elif label.startswith(r"$Li-PEO$ Renewal"):
             xdata, ydata = rnw_peo_data[:, 0], rnw_peo_data[:, 1]


### PR DESCRIPTION
# Lifetime Autocorrelation Functions: Correct Terminology

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [ ] New feature.
* [x] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

Python scripts `plot_lifetime_autocorr_*.py`: Replace the term "relaxation time" in labels, legends and created text files by the term "correlation time".

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [ ] New/changed code is properly documented.
* [ ] The CI workflow is passing.
