### PR TITLE
Create Scripts to Plot MSDs that Dependent on the Initial Particle Position (msd_layer)

### DIFF
--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_chain-length_dependence.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot a given component of the mean displacement and the displacement
+variance in each bin at a constant diffusion time as function of the PEO
+chain length.
+
+Only bins that correspond to actual layers (i.e. free-energy minima) at
+the electrode interface are taken into account.
+
+Layers/free-energy minima are clustered based on their distance to the
+electrode.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+import warnings
+from copy import deepcopy
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import FormatStrFormatter, MaxNLocator
+from scipy.cluster.hierarchy import dendrogram
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def legend_title(surfq_sign):
+    r"""
+    Create a legend title string.
+
+    Parameters
+    ----------
+    surfq_sign : {"+", "-", r"\pm"}
+        The sign of the surface charge.
+
+    Returns
+    -------
+    title : str
+        The legend title.
+
+    Notes
+    -----
+    This function relies on global variables!
+    """
+    if surfq_sign not in ("+", "-", r"\pm"):
+        raise ValueError("Unknown `surfq_sign`: '{}'".format(surfq_sign))
+
+    if args.cmp in ("NBT", "OBT", "OE"):
+        legend_title = (
+            "$" + leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + "$" + ", "
+        )
+    else:
+        legend_title = leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + ", "
+    legend_title += (
+        r"$\Delta t = %.1f$ ns" % args.time
+        + "\n"
+        + r"$\sigma_s = "
+        + surfq_sign
+        + r" %.2f$ $e$/nm$^2$, " % Sims.surfqs[0]
+        + r"$r = %.2f$" % Sims.Li_O_ratios[0]
+        + "\n"
+        + r"$F_{"
+        + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp_fe]
+        + r"}$ Minima"
+    )
+    return legend_title
+
+
+def equalize_yticks(ax):
+    """
+    Equalize y-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the y
+        ticks.
+    """
+    ylim = np.asarray(ax.get_ylim())
+    ylim_diff = ylim[-1] - ylim[0]
+    yticks = np.asarray(ax.get_yticks())
+    yticks_valid = (yticks >= ylim[0]) & (yticks <= ylim[-1])
+    yticks = yticks[yticks_valid]
+    if ylim_diff >= 10 and ylim_diff < 20:
+        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+    if np.all(yticks >= 0) and np.all(yticks < 10) and ylim_diff > 2:
+        ax.yaxis.set_major_formatter(FormatStrFormatter("%.1f"))
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot a given component of the mean displacement and the displacement"
+        " variance in each bin at a constant diffusion time as function of the"
+        " PEO chain length."
+    )
+)
+parser.add_argument(
+    "--surfq",
+    type=str,
+    required=True,
+    choices=("q0", "q0.25", "q0.5", "q0.75", "q1"),
+    help="Surface charge in e/nm^2.",
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=False,
+    default="Li",
+    choices=("Li", "NTf2", "ether", "NBT", "OBT", "OE"),
+    help="Compound.  Default: %(default)s",
+)
+parser.add_argument(
+    "--msd-component",
+    type=str,
+    required=False,
+    default="z",
+    choices=("xy", "z"),
+    help="The MSD component to use for the analysis.  Default: %(default)s",
+)
+parser.add_argument(
+    "--time",
+    type=float,
+    required=False,
+    default=1000,
+    help=(
+        "Diffusion time in ps for which to plot the displacements as function"
+        " of the initial particle position.  If no data are present at the"
+        " given diffusion time, the next nearest diffusion time for which data"
+        " are present is used.  Default: %(default)s"
+    ),
+)
+parser.add_argument(
+    "--prob-thresh",
+    type=float,
+    required=False,
+    default=0.5,
+    help=(
+        "Only consider the number of renewal events in layers/free-energy"
+        " minima whose prominence is at least such high that only"
+        " 100*PROB_THRESH percent of the particles have a higher 1-dimensional"
+        " kinetic energy.  Default: %(default)s"
+    ),
+)
+parser.add_argument(
+    "--n-clusters",
+    type=lambda val: mdt.fh.str2none_or_type(val, dtype=int),
+    required=False,
+    default=None,
+    help=(
+        "The maximum number of layer clusters to consider.  'None' means all"
+        " layer clusters.  Default: %(default)s"
+    ),
+)
+parser.add_argument(
+    "--common-ylim",
+    required=False,
+    default=False,
+    action="store_true",
+    help="Use common y limits for all plots.",
+)
+args = parser.parse_args()
+if args.prob_thresh < 0 or args.prob_thresh > 1:
+    raise ValueError(
+        "--prob-thresh ({}) must be between 0 and 1".format(args.prob_thresh)
+    )
+if args.n_clusters is not None and args.n_clusters <= 0:
+    raise ValueError(
+        "--n-cluster ({}) must be a positive integer".format(args.n_clusters)
+    )
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+analysis = "msd_layer"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+ana_path = os.path.join(analysis, analysis + analysis_suffix)
+tool = "mdt"  # Analysis software.
+outfile = (
+    settings
+    + "_lintf2_peoN_20-1_gra_"
+    + args.surfq
+    + "_sc80_"
+    + args.cmp
+    + "_displvar"
+    + args.msd_component
+    + "_cross_section_"
+    + "%.0fps" % args.time
+)
+if args.common_ylim:
+    outfile += "_common_ylim.pdf"
+else:
+    outfile += ".pdf"
+
+# Columns to read from the files that contain the free-energy extrema.
+pkp_col = 1  # Column that contains the peak positions in nm.
+pkm_col = 3  # Column that contains the peak prominences in kT.
+cols_fe = (pkp_col, pkm_col)  # Peak positions [nm].
+pkp_col_ix = cols_fe.index(pkp_col)
+pkm_col_ix = cols_fe.index(pkm_col)
+
+# The method to use for calculating the distance between clusters.  See
+# `scipy.cluster.hierarchy.linkage`.
+clstr_dist_method = "single"
+
+# Number of decimal places to use for the assignment of bin edges to
+# free-energy maxima.
+decimals = 3
+
+args.time /= 1e3  # ps -> ns.
+
+if args.msd_component == "xy":
+    dimensions = ("x", "y")
+elif args.msd_component == "z":
+    dimensions = ("z",)
+else:
+    raise ValueError(
+        "Unknown --msd-component: '{}'".format(args.msd_component)
+    )
+
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_[gp]*[0-9]*_20-1_gra_" + args.surfq + "_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, args.surfq, sort_key="O_per_chain"
+)
+
+
+print("Reading data...")
+# Read positions of free-energy extrema.
+cmp_fe = "Li"
+minima, n_minima_max = leap.simulation.read_free_energy_extrema(
+    Sims, cmp=cmp_fe, peak_type="minima", cols=cols_fe
+)
+maxima, n_maxima_max = leap.simulation.read_free_energy_extrema(
+    Sims, cmp=cmp_fe, peak_type="maxima", cols=cols_fe
+)
+if np.any(n_minima_max != n_maxima_max):
+    raise ValueError(
+        "Any `n_minima_max` ({}) != `n_maxima_max`"
+        " ({})".format(n_minima_max, n_maxima_max)
+    )
+
+Elctrd = leap.simulation.Electrode()
+elctrd_thk = Elctrd.ELCTRD_THK / 10  # A -> nm.
+bulk_start = Elctrd.BULK_START / 10  # A -> nm.
+pk_pos_types = ("left", "right")
+n_data = 3
+# Data:
+# 1) Free-energy minima positions (distance to electrode).
+# 2) Mean displacements.
+# 3) Displacement variances.
+ydata = [
+    [[[] for sim in Sims.sims] for pkp_type in pk_pos_types]
+    for dat_ix in range(n_data)
+]
+for sim_ix, Sim in enumerate(Sims.sims):
+    # Read displacements at the given time from file.
+    for dim_ix, dim in enumerate(dimensions):
+        (
+            times_dim,
+            bins_dim,
+            md_data,
+            msd_data,
+        ) = leap.simulation.read_displvar_single(Sim, args.cmp, dim)
+        if dim_ix == 0:
+            times, bins = times_dim, bins_dim
+            time, tix = mdt.nph.find_nearest(
+                times, args.time, return_index=True
+            )
+            if not np.isclose(time, args.time, atol=0):
+                raise ValueError(
+                    "The time given with --time ({} ns) is not contained in"
+                    " the input files.  The closest time is {}"
+                    " ns".format(args.time, time)
+                )
+            md_at_const_time = md_data[tix]
+            msd_at_const_time = msd_data[tix]
+        else:
+            if bins_dim.shape != bins.shape:
+                raise ValueError(
+                    "The input files do not contain the same number of bins"
+                )
+            if not np.allclose(bins_dim, bins, atol=0):
+                raise ValueError(
+                    "The bin edges are not the same in all input files"
+                )
+            if times_dim.shape != times.shape:
+                raise ValueError(
+                    "The input files do not contain the same number of lag"
+                    " times"
+                )
+            if not np.allclose(times_dim, times, atol=0):
+                raise ValueError(
+                    "The lag times are not the same in all input files"
+                )
+            time_dim, tix = mdt.nph.find_nearest(
+                times_dim, args.time, return_index=True
+            )
+            if not np.isclose(time_dim, time, atol=0):
+                raise ValueError(
+                    "The chosen lag time is not the same in all input files"
+                )
+            md_at_const_time += md_data[tix]
+            msd_at_const_time += msd_data[tix]
+    del times, times_dim, bins_dim, md_data, msd_data
+
+    box_z = Sim.box[2] / 10  # Angstrom -> nm.
+    for pkt_ix, pkp_type in enumerate(pk_pos_types):
+        # Convert absolute positions to distance to the electrode.
+        if pkp_type == "left":
+            bins_pkt = bins[1:] - elctrd_thk  # Upper bin edges.
+            md_at_const_time_pkt = md_at_const_time
+            msd_at_const_time_pkt = msd_at_const_time
+        elif pkp_type == "right":
+            bins_pkt = bins[:-1] + elctrd_thk  # Lower bin edges.
+            bins_pkt -= box_z
+            bins_pkt *= -1  # Ensure positive distance values.
+            bins_pkt = bins_pkt[::-1]
+            md_at_const_time_pkt = md_at_const_time[::-1]
+            msd_at_const_time_pkt = msd_at_const_time[::-1]
+        else:
+            raise ValueError("Unknown `pkp_type`: '{}'".format(pkp_type))
+
+        # Assign bin edges to free-energy maxima.
+        maxima_pkt = maxima[pkp_col_ix][pkt_ix][sim_ix]
+        if not np.all(maxima_pkt[:-1] <= maxima_pkt[1:]):
+            raise ValueError(
+                "The positions of the free-energy maxima are not sorted"
+            )
+        if not np.all(bins_pkt[:-1] <= bins_pkt[1:]):
+            raise ValueError("The bin edges are not sorted")
+        maxima_pkt = np.round(maxima_pkt, decimals=decimals, out=maxima_pkt)
+        bins_pkt = np.round(bins_pkt, decimals=decimals, out=bins_pkt)
+        valid_bins = np.isin(bins_pkt, maxima_pkt)
+        if np.count_nonzero(valid_bins) != len(maxima_pkt):
+            raise ValueError(
+                "The number of valid bins ({}) is not equal to the number of"
+                " free-energy maxima"
+                " ({})".format(np.count_nonzero(valid_bins), len(maxima_pkt))
+            )
+        first_valid = np.argmax(valid_bins) - 1
+        if (
+            args.cmp == cmp_fe
+            and args.time != 0  # At t=0 all displacements are zero.
+            and first_valid >= 0
+            and np.isfinite(md_at_const_time_pkt[first_valid])
+        ):
+            raise ValueError("A populated bin was marked as invalid.")
+
+        # Store data in list.
+        ydata[pkp_col_ix][pkt_ix][sim_ix] = minima[pkp_col_ix][pkt_ix][sim_ix]
+        ydata[1][pkt_ix][sim_ix] = md_at_const_time_pkt[valid_bins]
+        ydata[2][pkt_ix][sim_ix] = msd_at_const_time_pkt[valid_bins]
+del maxima
+
+
+print("Discarding free-energy minima whose prominence is too low...")
+prom_min = leap.misc.e_kin(args.prob_thresh)
+prominences = deepcopy(minima[pkm_col_ix])
+n_pks_max = [0 for prom_pkt in prominences]
+for col_ix, yd_col in enumerate(ydata):
+    for pkt_ix, yd_pkt in enumerate(yd_col):
+        for sim_ix, yd_sim in enumerate(yd_pkt):
+            valid = prominences[pkt_ix][sim_ix] >= prom_min
+            ydata[col_ix][pkt_ix][sim_ix] = yd_sim[valid]
+            n_pks_max[pkt_ix] = max(n_pks_max[pkt_ix], np.count_nonzero(valid))
+del minima, prominences
+
+
+print("Clustering peak positions...")
+(
+    ydata,
+    clstr_ix,
+    linkage_matrices,
+    n_clstrs,
+    n_pks_per_sim,
+    clstr_dist_thresh,
+) = leap.clstr.peak_pos(
+    ydata, pkp_col_ix, return_dist_thresh=True, method=clstr_dist_method
+)
+clstr_ix_unq = [np.unique(clstr_ix_pkt) for clstr_ix_pkt in clstr_ix]
+
+# Sort clusters by ascending average peak position and get cluster
+# boundaries.
+clstr_bounds = [None for clstr_ix_pkt in clstr_ix]
+for pkt_ix, clstr_ix_pkt in enumerate(clstr_ix):
+    _clstr_dists, clstr_ix[pkt_ix], bounds = leap.clstr.dists_succ(
+        ydata[pkp_col_ix][pkt_ix],
+        clstr_ix_pkt,
+        method=clstr_dist_method,
+        return_ix=True,
+        return_bounds=True,
+    )
+    clstr_bounds[pkt_ix] = np.append(bounds, bulk_start)
+
+if np.any(n_clstrs < n_pks_max):
+    warnings.warn(
+        "Any `n_clstrs` ({}) < `n_pks_max` ({}).  This means different"
+        " peaks of the same simulation were assigned to the same cluster."
+        "  Try to decrease the threshold distance"
+        " ({})".format(n_clstrs, n_pks_max, clstr_dist_thresh),
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+xdata = [None for n_pks_per_sim_pkt in n_pks_per_sim]
+for pkt_ix, n_pks_per_sim_pkt in enumerate(n_pks_per_sim):
+    if np.max(n_pks_per_sim_pkt) != n_pks_max[pkt_ix]:
+        raise ValueError(
+            "`np.max(n_pks_per_sim[{}])` ({}) != `n_pks_max[{}]` ({}).  This"
+            " should not have happened".format(
+                pkt_ix, np.max(n_pks_per_sim_pkt), pkt_ix, n_pks_max[pkt_ix]
+            )
+        )
+    xdata[pkt_ix] = [
+        Sims.O_per_chain[sim_ix]
+        for sim_ix, n_pks_sim in enumerate(n_pks_per_sim_pkt)
+        for _ in range(n_pks_sim)
+    ]
+    xdata[pkt_ix] = np.array(xdata[pkt_ix])
+
+
+print("Creating plot(s)...")
+n_clstrs_plot = np.max(n_clstrs)
+if args.n_clusters is not None:
+    n_clstrs_plot = min(n_clstrs_plot, args.n_clusters)
+if n_clstrs_plot <= 0:
+    raise ValueError("`n_clstrs_plot` ({}) <= 0".format(n_clstrs_plot))
+
+legend_title_suffix = " Positions / nm"
+n_legend_handles_comb = sum(min(n_cl, n_clstrs_plot) for n_cl in n_clstrs)
+n_legend_cols_comb = min(3, 1 + n_legend_handles_comb // (2 + 1))
+legend_locs_sep = tuple("best" for col_ix in range(n_data))
+legend_locs_comb = tuple("best" for col_ix in range(n_data))
+if len(legend_locs_sep) != n_data:
+    raise ValueError(
+        "`len(legend_locs_sep)` ({}) != `n_data`"
+        " ({})".format(len(legend_locs_sep), n_data)
+    )
+if len(legend_locs_comb) != n_data:
+    raise ValueError(
+        "`len(legend_locs_comb)` ({}) != `n_data`"
+        " ({})".format(len(legend_locs_comb), n_data)
+    )
+
+xlabel = r"Ether Oxygens per Chain $n_{EO}$"
+xlim = (1, 200)
+
+# 1) Free-energy minima positions (distance to electrode).
+ylabels = ["Distance to Electrode / nm"]
+# 2) Mean displacements.
+ylabel = r"$\langle \Delta "
+if args.msd_component == "xy":
+    ylabel += r"%s \rangle" % args.msd_component[0]
+    ylabel += r"+ \langle \Delta %s" % args.msd_component[1]
+elif args.msd_component == "z":
+    ylabel += r"%s" % args.msd_component
+else:
+    raise ValueError(
+        "Unknown --msd-component: '{}'".format(args.msd_component)
+    )
+ylabel += r" \rangle$ / nm"
+ylabels.append(ylabel)
+# 3) Displacement variances.
+ylabel = r"Var$[\Delta "
+if args.msd_component == "xy":
+    ylabel += r"\mathbf{r}_{%s}" % args.msd_component
+elif args.msd_component == "z":
+    ylabel += r"%s" % args.msd_component
+else:
+    raise ValueError(
+        "Unknown --msd-component: '{}'".format(args.msd_component)
+    )
+ylabel += r"]$ / nm$^2$"
+ylabels.append(ylabel)
+if len(ylabels) != n_data:
+    raise ValueError(
+        "`len(ylabels)` ({}) != `n_data` ({})".format(len(ylabels), n_data)
+    )
+
+logy = (  # Whether to use log scale for the y-axis.
+    False,  # Free-energy minima positions (distance to electrode).
+    False,  # Mean displacements.
+    True,  # Displacement variances.
+)
+if len(logy) != n_data:
+    raise ValueError(
+        "`len(logy)` ({}) != `n_data` ({})".format(len(logy), n_data)
+    )
+
+if args.common_ylim:
+    ylims = [
+        (0, 3.6),  # Free-energy minima positions.
+        (None, None),  # Mean displacements.
+        (None, None),  # Displacement variances.
+    ]
+else:
+    ylims = tuple((None, None) for col_ix in range(n_data))
+if len(ylims) != n_data:
+    raise ValueError(
+        "`len(ylims)` ({}) != `n_data` ({})".format(len(ylims), n_data)
+    )
+
+linestyles_comb = ("solid", "dashed")
+if len(linestyles_comb) != len(pk_pos_types):
+    raise ValueError(
+        "`len(linestyles_comb)` ({}) != `len(pk_pos_types)`"
+        " ({})".format(len(linestyles_comb), len(pk_pos_types))
+    )
+markers = ("<", ">")
+if len(markers) != len(pk_pos_types):
+    raise ValueError(
+        "`len(markers)` ({}) != `len(pk_pos_types)`"
+        " ({})".format(len(markers), len(pk_pos_types))
+    )
+
+cmap = plt.get_cmap()
+c_vals_sep = np.arange(n_clstrs_plot)
+c_norm_sep = n_clstrs_plot - 1
+c_vals_sep_normed = c_vals_sep / c_norm_sep
+colors_sep = cmap(c_vals_sep_normed)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    for col_ix, yd_col in enumerate(ydata):
+        # Peaks at left and right electrode combined in one plot.
+        fig_comb, ax_comb = plt.subplots(clear=True)
+
+        for pkt_ix, pkp_type in enumerate(pk_pos_types):
+            yd_pkt = yd_col[pkt_ix]
+
+            # Peaks at left and right electrode in separate plots.
+            fig_sep, ax_sep = plt.subplots(clear=True)
+            ax_sep.set_prop_cycle(color=colors_sep)
+
+            c_vals_comb = c_vals_sep + 0.5 * pkt_ix
+            c_norm_comb = c_norm_sep + 0.5 * (len(pk_pos_types) - 1)
+            c_vals_comb_normed = c_vals_comb / c_norm_comb
+            colors_comb = cmap(c_vals_comb_normed)
+            ax_comb.set_prop_cycle(color=colors_comb)
+
+            for cix_pkt in clstr_ix_unq[pkt_ix]:
+                if cix_pkt >= n_clstrs_plot:
+                    break
+
+                valid = clstr_ix[pkt_ix] == cix_pkt
+                if not np.any(valid):
+                    raise ValueError(
+                        "No valid peaks for peak type '{}' and cluster index"
+                        " {}".format(pkp_type, cix_pkt)
+                    )
+
+                if pkp_type == "left":
+                    label_sep = r"$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt]
+                    label_comb = r"$+, " + label_sep[1:]
+                elif pkp_type == "right":
+                    label_sep = r"$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt]
+                    label_comb = r"$-, " + label_sep[1:]
+                else:
+                    raise ValueError(
+                        "Unknown `pkp_type`: '{}'".format(pkp_type)
+                    )
+                ax_sep.plot(
+                    xdata[pkt_ix][valid],
+                    yd_pkt[valid],
+                    linestyle="solid",
+                    marker=markers[pkt_ix],
+                    label=label_sep,
+                )
+                ax_comb.plot(
+                    xdata[pkt_ix][valid],
+                    yd_pkt[valid],
+                    linestyle=linestyles_comb[pkt_ix],
+                    marker=markers[pkt_ix],
+                    label=label_comb,
+                )
+
+            if pkp_type == "left":
+                legend_title_sep = legend_title(r"+")
+            elif pkp_type == "right":
+                legend_title_sep = legend_title(r"-")
+            else:
+                raise ValueError("Unknown `pkp_type`: '{}'".format(pkp_type))
+            if col_ix == 0:
+                # Remove compound and lag time from legend title.
+                legend_title_sep = legend_title_sep.split("\n")[1:]
+                legend_title_sep = "\n".join(legend_title_sep)
+            ax_sep.set_xscale("log", base=10, subs=np.arange(2, 10))
+            if logy[col_ix]:
+                ax_sep.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax_sep.set(
+                xlabel=xlabel,
+                ylabel=ylabels[col_ix],
+                xlim=xlim,
+                ylim=ylims[col_ix],
+            )
+            if not logy[col_ix]:
+                equalize_yticks(ax_sep)
+            legend_sep = ax_sep.legend(
+                title=legend_title_sep + legend_title_suffix,
+                ncol=2,
+                loc=legend_locs_sep[col_ix],
+                **mdtplt.LEGEND_KWARGS_XSMALL,
+            )
+            legend_sep.get_title().set_multialignment("center")
+            pdf.savefig(fig_sep)
+            plt.close(fig_sep)
+
+        legend_title_comb = legend_title(r"\pm")
+        if col_ix == 0:
+            # Remove compound and lag time from legend title.
+            legend_title_comb = legend_title_comb.split("\n")[1:]
+            legend_title_comb = "\n".join(legend_title_comb)
+        ax_comb.set_xscale("log", base=10, subs=np.arange(2, 10))
+        if logy[col_ix]:
+            ax_comb.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax_comb.set(
+            xlabel=xlabel,
+            ylabel=ylabels[col_ix],
+            xlim=xlim,
+            ylim=ylims[col_ix],
+        )
+        if not logy[col_ix]:
+            equalize_yticks(ax_comb)
+        legend_comb = ax_comb.legend(
+            title=legend_title_comb + legend_title_suffix,
+            ncol=n_legend_cols_comb,
+            loc=legend_locs_comb[col_ix],
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend_comb.get_title().set_multialignment("center")
+        pdf.savefig(fig_comb)
+        plt.close(fig_comb)
+
+    # Plot clustering results.
+    for pkt_ix, pkp_type in enumerate(pk_pos_types):
+        if pkp_type == "left":
+            legend_title_clstrng = legend_title("+")
+        elif pkp_type == "right":
+            legend_title_clstrng = legend_title("-")
+        else:
+            raise ValueError("Unknown `pkp_type`: '{}'".format(pkp_type))
+        # Remove compound and lag time from legend title.
+        legend_title_clstrng = legend_title_clstrng.split("\n")[1:]
+        legend_title_clstrng = "\n".join(legend_title_clstrng)
+        cmap_norm = plt.Normalize(vmin=0, vmax=np.max(n_clstrs) - 1)
+
+        # Dendrogram.
+        fig, ax = plt.subplots(clear=True)
+        dendrogram(
+            linkage_matrices[pkt_ix],
+            ax=ax,
+            distance_sort="ascending",
+            color_threshold=clstr_dist_thresh[pkt_ix],
+        )
+        ax.axhline(
+            clstr_dist_thresh[pkt_ix],
+            color="tab:gray",
+            linestyle="dashed",
+            label=r"Threshold $%.2f$ nm" % clstr_dist_thresh[pkt_ix],
+        )
+        ax.set(
+            xlabel="Peak Number",
+            ylabel="Peak Distance / nm",
+            ylim=(0, ylims[pkp_col_ix][-1]),
+        )
+        legend = ax.legend(
+            title=legend_title_clstrng,
+            loc="best",
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+        # Scatter plot: Peak Positions vs. Peak Positions.
+        fig, ax = plt.subplots(clear=True)
+        for cix_pkt in clstr_ix_unq[pkt_ix]:
+            if cix_pkt >= n_clstrs_plot:
+                break
+            valid = clstr_ix[pkt_ix] == cix_pkt
+            if not np.any(valid):
+                raise ValueError(
+                    "No valid peaks for peak type '{}' and cluster index"
+                    " {}".format(pkp_type, cix_pkt)
+                )
+            ax.scatter(
+                ydata[pkp_col_ix][pkt_ix][valid],
+                ydata[pkp_col_ix][pkt_ix][valid],
+                color=cmap(cmap_norm(cix_pkt)),
+                marker=markers[pkt_ix],
+                label="$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt],
+            )
+        ax.set(
+            xlabel=ylabels[pkp_col_ix],
+            ylabel=ylabels[pkp_col_ix],
+            xlim=ylims[pkp_col_ix],
+            ylim=ylims[pkp_col_ix],
+        )
+        legend = ax.legend(
+            title=legend_title_clstrng + legend_title_suffix,
+            ncol=2,
+            loc="upper left",
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+        # Scatter plot: Peak Positions vs. `xdata`.
+        fig, ax = plt.subplots(clear=True)
+        for cix_pkt in clstr_ix_unq[pkt_ix]:
+            if cix_pkt >= n_clstrs_plot:
+                break
+            valid = clstr_ix[pkt_ix] == cix_pkt
+            if not np.any(valid):
+                raise ValueError(
+                    "No valid peaks for peak type '{}' and cluster index"
+                    " {}".format(pkp_type, cix_pkt)
+                )
+            ax.scatter(
+                xdata[pkt_ix][valid],
+                ydata[pkp_col_ix][pkt_ix][valid],
+                color=cmap(cmap_norm(cix_pkt)),
+                marker=markers[pkt_ix],
+                label="$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt],
+            )
+        ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(
+            xlabel=xlabel,
+            ylabel=ylabels[pkp_col_ix],
+            xlim=xlim,
+            ylim=ylims[pkp_col_ix],
+        )
+        equalize_yticks(ax)
+        legend = ax.legend(
+            title=legend_title_clstrng + legend_title_suffix,
+            ncol=2,
+            loc=legend_locs_sep[pkp_col_ix],
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_conc_dependence.py
@@ -1,0 +1,779 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot a given component of the mean displacement and the displacement
+variance in each bin at a constant diffusion time as function of the
+salt concentration.
+
+Only bins that correspond to actual layers (i.e. free-energy minima) at
+the electrode interface are taken into account.
+
+Layers/free-energy minima are clustered based on their distance to the
+electrode.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+import warnings
+from copy import deepcopy
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import FormatStrFormatter, MaxNLocator, MultipleLocator
+from scipy.cluster.hierarchy import dendrogram
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def legend_title(surfq_sign):
+    r"""
+    Create a legend title string.
+
+    Parameters
+    ----------
+    surfq_sign : {"+", "-", r"\pm"}
+        The sign of the surface charge.
+
+    Returns
+    -------
+    title : str
+        The legend title.
+
+    Notes
+    -----
+    This function relies on global variables!
+    """
+    if surfq_sign not in ("+", "-", r"\pm"):
+        raise ValueError("Unknown `surfq_sign`: '{}'".format(surfq_sign))
+
+    if args.cmp in ("NBT", "OBT", "OE"):
+        legend_title = (
+            "$" + leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + "$" + ", "
+        )
+    else:
+        legend_title = leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + ", "
+    legend_title += (
+        r"$\Delta t = %.1f$ ns" % args.time
+        + "\n"
+        + r"$\sigma_s = "
+        + surfq_sign
+        + r" %.2f$ $e$/nm$^2$, " % Sims.surfqs[0]
+        + r"$n_{EO} = %d$" % Sims.O_per_chain[0]
+        + "\n"
+        + r"$F_{"
+        + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp_fe]
+        + r"}$ Minima"
+    )
+    return legend_title
+
+
+def equalize_xticks(ax):
+    """
+    Equalize x-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the x
+        ticks.
+    """
+    ax.xaxis.set_major_locator(MultipleLocator(0.1))
+
+
+def equalize_yticks(ax):
+    """
+    Equalize y-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the y
+        ticks.
+    """
+    ylim = np.asarray(ax.get_ylim())
+    ylim_diff = ylim[-1] - ylim[0]
+    yticks = np.asarray(ax.get_yticks())
+    yticks_valid = (yticks >= ylim[0]) & (yticks <= ylim[-1])
+    yticks = yticks[yticks_valid]
+    if ylim_diff >= 10 and ylim_diff < 20:
+        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+    if np.all(yticks >= 0) and np.all(yticks < 10) and ylim_diff > 2:
+        ax.yaxis.set_major_formatter(FormatStrFormatter("%.1f"))
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot a given component of the mean displacement and the displacement"
+        " variance in each bin at a constant diffusion time as function of the"
+        " salt concentration."
+    )
+)
+parser.add_argument(
+    "--sol",
+    type=str,
+    required=True,
+    choices=("g1", "g4", "peo63"),
+    help="Solvent name.",
+)
+parser.add_argument(
+    "--surfq",
+    type=str,
+    required=True,
+    choices=("q0", "q1"),
+    help="Surface charge in e/nm^2.",
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=False,
+    default="Li",
+    choices=("Li", "NTf2", "ether", "NBT", "OBT", "OE"),
+    help="Compound.  Default: %(default)s",
+)
+parser.add_argument(
+    "--msd-component",
+    type=str,
+    required=False,
+    default="z",
+    choices=("xy", "z"),
+    help="The MSD component to use for the analysis.  Default: %(default)s",
+)
+parser.add_argument(
+    "--time",
+    type=float,
+    required=False,
+    default=1000,
+    help=(
+        "Diffusion time in ps for which to plot the displacements as function"
+        " of the initial particle position.  If no data are present at the"
+        " given diffusion time, the next nearest diffusion time for which data"
+        " are present is used.  Default: %(default)s"
+    ),
+)
+parser.add_argument(
+    "--prob-thresh",
+    type=float,
+    required=False,
+    default=0.5,
+    help=(
+        "Only consider the number of renewal events in layers/free-energy"
+        " minima whose prominence is at least such high that only"
+        " 100*PROB_THRESH percent of the particles have a higher 1-dimensional"
+        " kinetic energy.  Default: %(default)s"
+    ),
+)
+parser.add_argument(
+    "--n-clusters",
+    type=lambda val: mdt.fh.str2none_or_type(val, dtype=int),
+    required=False,
+    default=None,
+    help=(
+        "The maximum number of layer clusters to consider.  'None' means all"
+        " layer clusters.  Default: %(default)s"
+    ),
+)
+parser.add_argument(
+    "--common-ylim",
+    required=False,
+    default=False,
+    action="store_true",
+    help="Use common y limits for all plots.",
+)
+args = parser.parse_args()
+if args.prob_thresh < 0 or args.prob_thresh > 1:
+    raise ValueError(
+        "--prob-thresh ({}) must be between 0 and 1".format(args.prob_thresh)
+    )
+if args.n_clusters is not None and args.n_clusters <= 0:
+    raise ValueError(
+        "--n-cluster ({}) must be a positive integer".format(args.n_clusters)
+    )
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+analysis = "msd_layer"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+ana_path = os.path.join(analysis, analysis + analysis_suffix)
+tool = "mdt"  # Analysis software.
+outfile = (
+    settings
+    + "_lintf2_"
+    + args.sol
+    + "_r_gra_"
+    + args.surfq
+    + "_sc80_"
+    + args.cmp
+    + "_displvar"
+    + args.msd_component
+    + "_cross_section_"
+    + "%.0fps" % args.time
+)
+if args.common_ylim:
+    outfile += "_common_ylim.pdf"
+else:
+    outfile += ".pdf"
+
+# Columns to read from the files that contain the free-energy extrema.
+pkp_col = 1  # Column that contains the peak positions in nm.
+pkm_col = 3  # Column that contains the peak prominences in kT.
+cols_fe = (pkp_col, pkm_col)  # Peak positions [nm].
+pkp_col_ix = cols_fe.index(pkp_col)
+pkm_col_ix = cols_fe.index(pkm_col)
+
+# The method to use for calculating the distance between clusters.  See
+# `scipy.cluster.hierarchy.linkage`.
+clstr_dist_method = "single"
+
+# Number of decimal places to use for the assignment of bin edges to
+# free-energy maxima.
+decimals = 3
+
+args.time /= 1e3  # ps -> ns.
+
+if args.msd_component == "xy":
+    dimensions = ("x", "y")
+elif args.msd_component == "z":
+    dimensions = ("z",)
+else:
+    raise ValueError(
+        "Unknown --msd-component: '{}'".format(args.msd_component)
+    )
+
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_" + args.sol + "_[0-9]*-[0-9]*_gra_" + args.surfq + "_sc80"
+excl_pat = "lintf2_[A-z]*[0-9]*_80-1_gra_q1_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, args.surfq, excl_pat, sort_key="Li_O_ratio"
+)
+
+
+print("Reading data...")
+# Read positions of free-energy extrema.
+cmp_fe = "Li"
+minima, n_minima_max = leap.simulation.read_free_energy_extrema(
+    Sims, cmp=cmp_fe, peak_type="minima", cols=cols_fe
+)
+maxima, n_maxima_max = leap.simulation.read_free_energy_extrema(
+    Sims, cmp=cmp_fe, peak_type="maxima", cols=cols_fe
+)
+if np.any(n_minima_max != n_maxima_max):
+    raise ValueError(
+        "Any `n_minima_max` ({}) != `n_maxima_max`"
+        " ({})".format(n_minima_max, n_maxima_max)
+    )
+
+Elctrd = leap.simulation.Electrode()
+elctrd_thk = Elctrd.ELCTRD_THK / 10  # A -> nm.
+bulk_start = Elctrd.BULK_START / 10  # A -> nm.
+pk_pos_types = ("left", "right")
+n_data = 3
+# Data:
+# 1) Free-energy minima positions (distance to electrode).
+# 2) Mean displacements.
+# 3) Displacement variances.
+ydata = [
+    [[[] for sim in Sims.sims] for pkp_type in pk_pos_types]
+    for dat_ix in range(n_data)
+]
+for sim_ix, Sim in enumerate(Sims.sims):
+    # Read displacements at the given time from file.
+    for dim_ix, dim in enumerate(dimensions):
+        (
+            times_dim,
+            bins_dim,
+            md_data,
+            msd_data,
+        ) = leap.simulation.read_displvar_single(Sim, args.cmp, dim)
+        if dim_ix == 0:
+            times, bins = times_dim, bins_dim
+            time, tix = mdt.nph.find_nearest(
+                times, args.time, return_index=True
+            )
+            if not np.isclose(time, args.time, atol=0):
+                raise ValueError(
+                    "The time given with --time ({} ns) is not contained in"
+                    " the input files.  The closest time is {}"
+                    " ns".format(args.time, time)
+                )
+            md_at_const_time = md_data[tix]
+            msd_at_const_time = msd_data[tix]
+        else:
+            if bins_dim.shape != bins.shape:
+                raise ValueError(
+                    "The input files do not contain the same number of bins"
+                )
+            if not np.allclose(bins_dim, bins, atol=0):
+                raise ValueError(
+                    "The bin edges are not the same in all input files"
+                )
+            if times_dim.shape != times.shape:
+                raise ValueError(
+                    "The input files do not contain the same number of lag"
+                    " times"
+                )
+            if not np.allclose(times_dim, times, atol=0):
+                raise ValueError(
+                    "The lag times are not the same in all input files"
+                )
+            time_dim, tix = mdt.nph.find_nearest(
+                times_dim, args.time, return_index=True
+            )
+            if not np.isclose(time_dim, time, atol=0):
+                raise ValueError(
+                    "The chosen lag time is not the same in all input files"
+                )
+            md_at_const_time += md_data[tix]
+            msd_at_const_time += msd_data[tix]
+    del times, times_dim, bins_dim, md_data, msd_data
+
+    box_z = Sim.box[2] / 10  # Angstrom -> nm.
+    for pkt_ix, pkp_type in enumerate(pk_pos_types):
+        # Convert absolute positions to distance to the electrode.
+        if pkp_type == "left":
+            bins_pkt = bins[1:] - elctrd_thk  # Upper bin edges.
+            md_at_const_time_pkt = md_at_const_time
+            msd_at_const_time_pkt = msd_at_const_time
+        elif pkp_type == "right":
+            bins_pkt = bins[:-1] + elctrd_thk  # Lower bin edges.
+            bins_pkt -= box_z
+            bins_pkt *= -1  # Ensure positive distance values.
+            bins_pkt = bins_pkt[::-1]
+            md_at_const_time_pkt = md_at_const_time[::-1]
+            msd_at_const_time_pkt = msd_at_const_time[::-1]
+        else:
+            raise ValueError("Unknown `pkp_type`: '{}'".format(pkp_type))
+
+        # Assign bin edges to free-energy maxima.
+        maxima_pkt = maxima[pkp_col_ix][pkt_ix][sim_ix]
+        if not np.all(maxima_pkt[:-1] <= maxima_pkt[1:]):
+            raise ValueError(
+                "The positions of the free-energy maxima are not sorted"
+            )
+        if not np.all(bins_pkt[:-1] <= bins_pkt[1:]):
+            raise ValueError("The bin edges are not sorted")
+        maxima_pkt = np.round(maxima_pkt, decimals=decimals, out=maxima_pkt)
+        bins_pkt = np.round(bins_pkt, decimals=decimals, out=bins_pkt)
+        valid_bins = np.isin(bins_pkt, maxima_pkt)
+        if np.count_nonzero(valid_bins) != len(maxima_pkt):
+            raise ValueError(
+                "The number of valid bins ({}) is not equal to the number of"
+                " free-energy maxima"
+                " ({})".format(np.count_nonzero(valid_bins), len(maxima_pkt))
+            )
+        first_valid = np.argmax(valid_bins) - 1
+        if (
+            args.cmp == cmp_fe
+            and args.time != 0  # At t=0 all displacements are zero.
+            and first_valid >= 0
+            and np.isfinite(md_at_const_time_pkt[first_valid])
+        ):
+            raise ValueError("A populated bin was marked as invalid.")
+
+        # Store data in list.
+        ydata[pkp_col_ix][pkt_ix][sim_ix] = minima[pkp_col_ix][pkt_ix][sim_ix]
+        ydata[1][pkt_ix][sim_ix] = md_at_const_time_pkt[valid_bins]
+        ydata[2][pkt_ix][sim_ix] = msd_at_const_time_pkt[valid_bins]
+del maxima
+
+
+print("Discarding free-energy minima whose prominence is too low...")
+prom_min = leap.misc.e_kin(args.prob_thresh)
+prominences = deepcopy(minima[pkm_col_ix])
+n_pks_max = [0 for prom_pkt in prominences]
+for col_ix, yd_col in enumerate(ydata):
+    for pkt_ix, yd_pkt in enumerate(yd_col):
+        for sim_ix, yd_sim in enumerate(yd_pkt):
+            valid = prominences[pkt_ix][sim_ix] >= prom_min
+            ydata[col_ix][pkt_ix][sim_ix] = yd_sim[valid]
+            n_pks_max[pkt_ix] = max(n_pks_max[pkt_ix], np.count_nonzero(valid))
+del minima, prominences
+
+
+print("Clustering peak positions...")
+(
+    ydata,
+    clstr_ix,
+    linkage_matrices,
+    n_clstrs,
+    n_pks_per_sim,
+    clstr_dist_thresh,
+) = leap.clstr.peak_pos(
+    ydata, pkp_col_ix, return_dist_thresh=True, method=clstr_dist_method
+)
+clstr_ix_unq = [np.unique(clstr_ix_pkt) for clstr_ix_pkt in clstr_ix]
+
+# Sort clusters by ascending average peak position and get cluster
+# boundaries.
+clstr_bounds = [None for clstr_ix_pkt in clstr_ix]
+for pkt_ix, clstr_ix_pkt in enumerate(clstr_ix):
+    _clstr_dists, clstr_ix[pkt_ix], bounds = leap.clstr.dists_succ(
+        ydata[pkp_col_ix][pkt_ix],
+        clstr_ix_pkt,
+        method=clstr_dist_method,
+        return_ix=True,
+        return_bounds=True,
+    )
+    clstr_bounds[pkt_ix] = np.append(bounds, bulk_start)
+
+if np.any(n_clstrs < n_pks_max):
+    warnings.warn(
+        "Any `n_clstrs` ({}) < `n_pks_max` ({}).  This means different"
+        " peaks of the same simulation were assigned to the same cluster."
+        "  Try to decrease the threshold distance"
+        " ({})".format(n_clstrs, n_pks_max, clstr_dist_thresh),
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+xdata = [None for n_pks_per_sim_pkt in n_pks_per_sim]
+for pkt_ix, n_pks_per_sim_pkt in enumerate(n_pks_per_sim):
+    if np.max(n_pks_per_sim_pkt) != n_pks_max[pkt_ix]:
+        raise ValueError(
+            "`np.max(n_pks_per_sim[{}])` ({}) != `n_pks_max[{}]` ({}).  This"
+            " should not have happened".format(
+                pkt_ix, np.max(n_pks_per_sim_pkt), pkt_ix, n_pks_max[pkt_ix]
+            )
+        )
+    xdata[pkt_ix] = [
+        Sims.Li_O_ratios[sim_ix]
+        for sim_ix, n_pks_sim in enumerate(n_pks_per_sim_pkt)
+        for _ in range(n_pks_sim)
+    ]
+    xdata[pkt_ix] = np.array(xdata[pkt_ix])
+
+
+print("Creating plot(s)...")
+n_clstrs_plot = np.max(n_clstrs)
+if args.n_clusters is not None:
+    n_clstrs_plot = min(n_clstrs_plot, args.n_clusters)
+if n_clstrs_plot <= 0:
+    raise ValueError("`n_clstrs_plot` ({}) <= 0".format(n_clstrs_plot))
+
+legend_title_suffix = " Positions / nm"
+n_legend_handles_comb = sum(min(n_cl, n_clstrs_plot) for n_cl in n_clstrs)
+n_legend_cols_comb = min(3, 1 + n_legend_handles_comb // (2 + 1))
+legend_locs_sep = tuple("best" for col_ix in range(n_data))
+legend_locs_comb = tuple("best" for col_ix in range(n_data))
+if len(legend_locs_sep) != n_data:
+    raise ValueError(
+        "`len(legend_locs_sep)` ({}) != `n_data`"
+        " ({})".format(len(legend_locs_sep), n_data)
+    )
+if len(legend_locs_comb) != n_data:
+    raise ValueError(
+        "`len(legend_locs_comb)` ({}) != `n_data`"
+        " ({})".format(len(legend_locs_comb), n_data)
+    )
+
+xlabel = r"Li-to-EO Ratio $r$"
+xlim = (0, 0.4 + 0.0125)
+
+# 1) Free-energy minima positions (distance to electrode).
+ylabels = ["Distance to Electrode / nm"]
+# 2) Mean displacements.
+ylabel = r"$\langle \Delta "
+if args.msd_component == "xy":
+    ylabel += r"%s \rangle" % args.msd_component[0]
+    ylabel += r"+ \langle \Delta %s" % args.msd_component[1]
+elif args.msd_component == "z":
+    ylabel += r"%s" % args.msd_component
+else:
+    raise ValueError(
+        "Unknown --msd-component: '{}'".format(args.msd_component)
+    )
+ylabel += r" \rangle$ / nm"
+ylabels.append(ylabel)
+# 3) Displacement variances.
+ylabel = r"Var$[\Delta "
+if args.msd_component == "xy":
+    ylabel += r"\mathbf{r}_{%s}" % args.msd_component
+elif args.msd_component == "z":
+    ylabel += r"%s" % args.msd_component
+else:
+    raise ValueError(
+        "Unknown --msd-component: '{}'".format(args.msd_component)
+    )
+ylabel += r"]$ / nm$^2$"
+ylabels.append(ylabel)
+if len(ylabels) != n_data:
+    raise ValueError(
+        "`len(ylabels)` ({}) != `n_data` ({})".format(len(ylabels), n_data)
+    )
+
+logy = (  # Whether to use log scale for the y-axis.
+    False,  # Free-energy minima positions (distance to electrode).
+    False,  # Mean displacements.
+    True,  # Displacement variances.
+)
+if len(logy) != n_data:
+    raise ValueError(
+        "`len(logy)` ({}) != `n_data` ({})".format(len(logy), n_data)
+    )
+
+if args.common_ylim:
+    ylims = [
+        (0, 3.6),  # Free-energy minima positions.
+        (None, None),  # Mean displacements.
+        (None, None),  # Displacement variances.
+    ]
+else:
+    ylims = tuple((None, None) for col_ix in range(n_data))
+if len(ylims) != n_data:
+    raise ValueError(
+        "`len(ylims)` ({}) != `n_data` ({})".format(len(ylims), n_data)
+    )
+
+linestyles_comb = ("solid", "dashed")
+if len(linestyles_comb) != len(pk_pos_types):
+    raise ValueError(
+        "`len(linestyles_comb)` ({}) != `len(pk_pos_types)`"
+        " ({})".format(len(linestyles_comb), len(pk_pos_types))
+    )
+markers = ("<", ">")
+if len(markers) != len(pk_pos_types):
+    raise ValueError(
+        "`len(markers)` ({}) != `len(pk_pos_types)`"
+        " ({})".format(len(markers), len(pk_pos_types))
+    )
+
+cmap = plt.get_cmap()
+c_vals_sep = np.arange(n_clstrs_plot)
+c_norm_sep = n_clstrs_plot - 1
+c_vals_sep_normed = c_vals_sep / c_norm_sep
+colors_sep = cmap(c_vals_sep_normed)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    for col_ix, yd_col in enumerate(ydata):
+        # Peaks at left and right electrode combined in one plot.
+        fig_comb, ax_comb = plt.subplots(clear=True)
+
+        for pkt_ix, pkp_type in enumerate(pk_pos_types):
+            yd_pkt = yd_col[pkt_ix]
+
+            # Peaks at left and right electrode in separate plots.
+            fig_sep, ax_sep = plt.subplots(clear=True)
+            ax_sep.set_prop_cycle(color=colors_sep)
+
+            c_vals_comb = c_vals_sep + 0.5 * pkt_ix
+            c_norm_comb = c_norm_sep + 0.5 * (len(pk_pos_types) - 1)
+            c_vals_comb_normed = c_vals_comb / c_norm_comb
+            colors_comb = cmap(c_vals_comb_normed)
+            ax_comb.set_prop_cycle(color=colors_comb)
+
+            for cix_pkt in clstr_ix_unq[pkt_ix]:
+                if cix_pkt >= n_clstrs_plot:
+                    break
+
+                valid = clstr_ix[pkt_ix] == cix_pkt
+                if not np.any(valid):
+                    raise ValueError(
+                        "No valid peaks for peak type '{}' and cluster index"
+                        " {}".format(pkp_type, cix_pkt)
+                    )
+
+                if pkp_type == "left":
+                    label_sep = r"$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt]
+                    label_comb = r"$+, " + label_sep[1:]
+                elif pkp_type == "right":
+                    label_sep = r"$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt]
+                    label_comb = r"$-, " + label_sep[1:]
+                else:
+                    raise ValueError(
+                        "Unknown `pkp_type`: '{}'".format(pkp_type)
+                    )
+                ax_sep.plot(
+                    xdata[pkt_ix][valid],
+                    yd_pkt[valid],
+                    linestyle="solid",
+                    marker=markers[pkt_ix],
+                    label=label_sep,
+                )
+                ax_comb.plot(
+                    xdata[pkt_ix][valid],
+                    yd_pkt[valid],
+                    linestyle=linestyles_comb[pkt_ix],
+                    marker=markers[pkt_ix],
+                    label=label_comb,
+                )
+
+            if pkp_type == "left":
+                legend_title_sep = legend_title(r"+")
+            elif pkp_type == "right":
+                legend_title_sep = legend_title(r"-")
+            else:
+                raise ValueError("Unknown `pkp_type`: '{}'".format(pkp_type))
+            if col_ix == 0:
+                # Remove compound and lag time from legend title.
+                legend_title_sep = legend_title_sep.split("\n")[1:]
+                legend_title_sep = "\n".join(legend_title_sep)
+            if logy[col_ix]:
+                ax_sep.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax_sep.set(
+                xlabel=xlabel,
+                ylabel=ylabels[col_ix],
+                xlim=xlim,
+                ylim=ylims[col_ix],
+            )
+            equalize_xticks(ax_sep)
+            if not logy[col_ix]:
+                equalize_yticks(ax_sep)
+            legend_sep = ax_sep.legend(
+                title=legend_title_sep + legend_title_suffix,
+                ncol=2,
+                loc=legend_locs_sep[col_ix],
+                **mdtplt.LEGEND_KWARGS_XSMALL,
+            )
+            legend_sep.get_title().set_multialignment("center")
+            pdf.savefig(fig_sep)
+            plt.close(fig_sep)
+
+        legend_title_comb = legend_title(r"\pm")
+        if col_ix == 0:
+            # Remove compound and lag time from legend title.
+            legend_title_comb = legend_title_comb.split("\n")[1:]
+            legend_title_comb = "\n".join(legend_title_comb)
+        if logy[col_ix]:
+            ax_comb.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax_comb.set(
+            xlabel=xlabel,
+            ylabel=ylabels[col_ix],
+            xlim=xlim,
+            ylim=ylims[col_ix],
+        )
+        equalize_xticks(ax_comb)
+        if not logy[col_ix]:
+            equalize_yticks(ax_comb)
+        legend_comb = ax_comb.legend(
+            title=legend_title_comb + legend_title_suffix,
+            ncol=n_legend_cols_comb,
+            loc=legend_locs_comb[col_ix],
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend_comb.get_title().set_multialignment("center")
+        pdf.savefig(fig_comb)
+        plt.close(fig_comb)
+
+    # Plot clustering results.
+    for pkt_ix, pkp_type in enumerate(pk_pos_types):
+        if pkp_type == "left":
+            legend_title_clstrng = legend_title("+")
+        elif pkp_type == "right":
+            legend_title_clstrng = legend_title("-")
+        else:
+            raise ValueError("Unknown `pkp_type`: '{}'".format(pkp_type))
+        # Remove compound and lag time from legend title.
+        legend_title_clstrng = legend_title_clstrng.split("\n")[1:]
+        legend_title_clstrng = "\n".join(legend_title_clstrng)
+        cmap_norm = plt.Normalize(vmin=0, vmax=np.max(n_clstrs) - 1)
+
+        # Dendrogram.
+        fig, ax = plt.subplots(clear=True)
+        dendrogram(
+            linkage_matrices[pkt_ix],
+            ax=ax,
+            distance_sort="ascending",
+            color_threshold=clstr_dist_thresh[pkt_ix],
+        )
+        ax.axhline(
+            clstr_dist_thresh[pkt_ix],
+            color="tab:gray",
+            linestyle="dashed",
+            label=r"Threshold $%.2f$ nm" % clstr_dist_thresh[pkt_ix],
+        )
+        ax.set(
+            xlabel="Peak Number",
+            ylabel="Peak Distance / nm",
+            ylim=(0, ylims[pkp_col_ix][-1]),
+        )
+        legend = ax.legend(
+            title=legend_title_clstrng,
+            loc="best",
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+        # Scatter plot: Peak Positions vs. Peak Positions.
+        fig, ax = plt.subplots(clear=True)
+        for cix_pkt in clstr_ix_unq[pkt_ix]:
+            if cix_pkt >= n_clstrs_plot:
+                break
+            valid = clstr_ix[pkt_ix] == cix_pkt
+            if not np.any(valid):
+                raise ValueError(
+                    "No valid peaks for peak type '{}' and cluster index"
+                    " {}".format(pkp_type, cix_pkt)
+                )
+            ax.scatter(
+                ydata[pkp_col_ix][pkt_ix][valid],
+                ydata[pkp_col_ix][pkt_ix][valid],
+                color=cmap(cmap_norm(cix_pkt)),
+                marker=markers[pkt_ix],
+                label="$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt],
+            )
+        ax.set(
+            xlabel=ylabels[pkp_col_ix],
+            ylabel=ylabels[pkp_col_ix],
+            xlim=ylims[pkp_col_ix],
+            ylim=ylims[pkp_col_ix],
+        )
+        legend = ax.legend(
+            title=legend_title_clstrng + legend_title_suffix,
+            ncol=2,
+            loc="upper left",
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+        # Scatter plot: Peak Positions vs. `xdata`.
+        fig, ax = plt.subplots(clear=True)
+        for cix_pkt in clstr_ix_unq[pkt_ix]:
+            if cix_pkt >= n_clstrs_plot:
+                break
+            valid = clstr_ix[pkt_ix] == cix_pkt
+            if not np.any(valid):
+                raise ValueError(
+                    "No valid peaks for peak type '{}' and cluster index"
+                    " {}".format(pkp_type, cix_pkt)
+                )
+            ax.scatter(
+                xdata[pkt_ix][valid],
+                ydata[pkp_col_ix][pkt_ix][valid],
+                color=cmap(cmap_norm(cix_pkt)),
+                marker=markers[pkt_ix],
+                label="$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt],
+            )
+        ax.set(
+            xlabel=xlabel,
+            ylabel=ylabels[pkp_col_ix],
+            xlim=xlim,
+            ylim=ylims[pkp_col_ix],
+        )
+        equalize_xticks(ax)
+        equalize_yticks(ax)
+        legend = ax.legend(
+            title=legend_title_clstrng + legend_title_suffix,
+            ncol=2,
+            loc=legend_locs_sep[pkp_col_ix],
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_surfq_dependence.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_surfq_dependence.py
@@ -1,0 +1,749 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot a given component of the mean displacement and the displacement
+variance in each bin at a constant diffusion time as function of the
+electrode surface charge.
+
+Only bins that correspond to actual layers (i.e. free-energy minima) at
+the electrode interface are taken into account.
+
+Layers/free-energy minima are clustered based on their distance to the
+electrode.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+import warnings
+from copy import deepcopy
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import FormatStrFormatter, MaxNLocator, MultipleLocator
+from scipy.cluster.hierarchy import dendrogram
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def equalize_xticks(ax):
+    """
+    Equalize x-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the x
+        ticks.
+    """
+    ax.xaxis.set_major_locator(MultipleLocator(0.25))
+
+
+def equalize_yticks(ax):
+    """
+    Equalize y-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the y
+        ticks.
+    """
+    ylim = np.asarray(ax.get_ylim())
+    ylim_diff = ylim[-1] - ylim[0]
+    yticks = np.asarray(ax.get_yticks())
+    yticks_valid = (yticks >= ylim[0]) & (yticks <= ylim[-1])
+    yticks = yticks[yticks_valid]
+    if ylim_diff >= 10 and ylim_diff < 20:
+        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+    if np.all(yticks >= 0) and np.all(yticks < 10) and ylim_diff > 2:
+        ax.yaxis.set_major_formatter(FormatStrFormatter("%.1f"))
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot a given component of the mean displacement and the displacement"
+        " variance in each bin at a constant diffusion time as function of the"
+        " electrode surface charge."
+    )
+)
+parser.add_argument(
+    "--sol",
+    type=str,
+    required=True,
+    choices=("g1", "g4", "peo63"),
+    help="Solvent name.",
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=False,
+    default="Li",
+    choices=("Li", "NTf2", "ether", "NBT", "OBT", "OE"),
+    help="Compound.  Default: %(default)s",
+)
+parser.add_argument(
+    "--msd-component",
+    type=str,
+    required=False,
+    default="z",
+    choices=("xy", "z"),
+    help="The MSD component to use for the analysis.  Default: %(default)s",
+)
+parser.add_argument(
+    "--time",
+    type=float,
+    required=False,
+    default=1000,
+    help=(
+        "Diffusion time in ps for which to plot the displacements as function"
+        " of the initial particle position.  If no data are present at the"
+        " given diffusion time, the next nearest diffusion time for which data"
+        " are present is used.  Default: %(default)s"
+    ),
+)
+parser.add_argument(
+    "--prob-thresh",
+    type=float,
+    required=False,
+    default=0.5,
+    help=(
+        "Only consider the number of renewal events in layers/free-energy"
+        " minima whose prominence is at least such high that only"
+        " 100*PROB_THRESH percent of the particles have a higher 1-dimensional"
+        " kinetic energy.  Default: %(default)s"
+    ),
+)
+parser.add_argument(
+    "--n-clusters",
+    type=lambda val: mdt.fh.str2none_or_type(val, dtype=int),
+    required=False,
+    default=None,
+    help=(
+        "The maximum number of layer clusters to consider.  'None' means all"
+        " layer clusters.  Default: %(default)s"
+    ),
+)
+parser.add_argument(
+    "--common-ylim",
+    required=False,
+    default=False,
+    action="store_true",
+    help="Use common y limits for all plots.",
+)
+args = parser.parse_args()
+if args.prob_thresh < 0 or args.prob_thresh > 1:
+    raise ValueError(
+        "--prob-thresh ({}) must be between 0 and 1".format(args.prob_thresh)
+    )
+if args.n_clusters is not None and args.n_clusters <= 0:
+    raise ValueError(
+        "--n-cluster ({}) must be a positive integer".format(args.n_clusters)
+    )
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+analysis = "msd_layer"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+ana_path = os.path.join(analysis, analysis + analysis_suffix)
+tool = "mdt"  # Analysis software.
+outfile = (
+    settings
+    + "_lintf2_"
+    + args.sol
+    + "_20-1_gra_qX_sc80_"
+    + args.cmp
+    + "_displvar"
+    + args.msd_component
+    + "_cross_section_"
+    + "%.0fps" % args.time
+)
+if args.common_ylim:
+    outfile += "_common_ylim.pdf"
+else:
+    outfile += ".pdf"
+
+# Columns to read from the files that contain the free-energy extrema.
+pkp_col = 1  # Column that contains the peak positions in nm.
+pkm_col = 3  # Column that contains the peak prominences in kT.
+cols_fe = (pkp_col, pkm_col)  # Peak positions [nm].
+pkp_col_ix = cols_fe.index(pkp_col)
+pkm_col_ix = cols_fe.index(pkm_col)
+
+# The method to use for calculating the distance between clusters.  See
+# `scipy.cluster.hierarchy.linkage`.
+clstr_dist_method = "single"
+
+# Number of decimal places to use for the assignment of bin edges to
+# free-energy maxima.
+decimals = 3
+
+args.time /= 1e3  # ps -> ns.
+
+if args.msd_component == "xy":
+    dimensions = ("x", "y")
+elif args.msd_component == "z":
+    dimensions = ("z",)
+else:
+    raise ValueError(
+        "Unknown --msd-component: '{}'".format(args.msd_component)
+    )
+
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_" + args.sol + "_20-1_gra_q[0-9]*_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+sys_pat = os.path.join("q[0-9]*", sys_pat)
+Sims = leap.simulation.get_sims(sys_pat, set_pat, "walls", sort_key="surfq")
+
+
+print("Reading data...")
+# Read positions of free-energy extrema.
+cmp_fe = "Li"
+minima, n_minima_max = leap.simulation.read_free_energy_extrema(
+    Sims, cmp=cmp_fe, peak_type="minima", cols=cols_fe
+)
+maxima, n_maxima_max = leap.simulation.read_free_energy_extrema(
+    Sims, cmp=cmp_fe, peak_type="maxima", cols=cols_fe
+)
+if np.any(n_minima_max != n_maxima_max):
+    raise ValueError(
+        "Any `n_minima_max` ({}) != `n_maxima_max`"
+        " ({})".format(n_minima_max, n_maxima_max)
+    )
+
+Elctrd = leap.simulation.Electrode()
+elctrd_thk = Elctrd.ELCTRD_THK / 10  # A -> nm.
+bulk_start = Elctrd.BULK_START / 10  # A -> nm.
+pk_pos_types = ("left", "right")
+n_data = 3
+# Data:
+# 1) Free-energy minima positions (distance to electrode).
+# 2) Mean displacements.
+# 3) Displacement variances.
+ydata = [
+    [[[] for sim in Sims.sims] for pkp_type in pk_pos_types]
+    for dat_ix in range(n_data)
+]
+for sim_ix, Sim in enumerate(Sims.sims):
+    # Read displacements at the given time from file.
+    for dim_ix, dim in enumerate(dimensions):
+        (
+            times_dim,
+            bins_dim,
+            md_data,
+            msd_data,
+        ) = leap.simulation.read_displvar_single(Sim, args.cmp, dim)
+        if dim_ix == 0:
+            times, bins = times_dim, bins_dim
+            time, tix = mdt.nph.find_nearest(
+                times, args.time, return_index=True
+            )
+            if not np.isclose(time, args.time, atol=0):
+                raise ValueError(
+                    "The time given with --time ({} ns) is not contained in"
+                    " the input files.  The closest time is {}"
+                    " ns".format(args.time, time)
+                )
+            md_at_const_time = md_data[tix]
+            msd_at_const_time = msd_data[tix]
+        else:
+            if bins_dim.shape != bins.shape:
+                raise ValueError(
+                    "The input files do not contain the same number of bins"
+                )
+            if not np.allclose(bins_dim, bins, atol=0):
+                raise ValueError(
+                    "The bin edges are not the same in all input files"
+                )
+            if times_dim.shape != times.shape:
+                raise ValueError(
+                    "The input files do not contain the same number of lag"
+                    " times"
+                )
+            if not np.allclose(times_dim, times, atol=0):
+                raise ValueError(
+                    "The lag times are not the same in all input files"
+                )
+            time_dim, tix = mdt.nph.find_nearest(
+                times_dim, args.time, return_index=True
+            )
+            if not np.isclose(time_dim, time, atol=0):
+                raise ValueError(
+                    "The chosen lag time is not the same in all input files"
+                )
+            md_at_const_time += md_data[tix]
+            msd_at_const_time += msd_data[tix]
+    del times, times_dim, bins_dim, md_data, msd_data
+
+    box_z = Sim.box[2] / 10  # Angstrom -> nm.
+    for pkt_ix, pkp_type in enumerate(pk_pos_types):
+        # Convert absolute positions to distance to the electrode.
+        if pkp_type == "left":
+            bins_pkt = bins[1:] - elctrd_thk  # Upper bin edges.
+            md_at_const_time_pkt = md_at_const_time
+            msd_at_const_time_pkt = msd_at_const_time
+        elif pkp_type == "right":
+            bins_pkt = bins[:-1] + elctrd_thk  # Lower bin edges.
+            bins_pkt -= box_z
+            bins_pkt *= -1  # Ensure positive distance values.
+            bins_pkt = bins_pkt[::-1]
+            md_at_const_time_pkt = md_at_const_time[::-1]
+            msd_at_const_time_pkt = msd_at_const_time[::-1]
+        else:
+            raise ValueError("Unknown `pkp_type`: '{}'".format(pkp_type))
+
+        # Assign bin edges to free-energy maxima.
+        maxima_pkt = maxima[pkp_col_ix][pkt_ix][sim_ix]
+        if not np.all(maxima_pkt[:-1] <= maxima_pkt[1:]):
+            raise ValueError(
+                "The positions of the free-energy maxima are not sorted"
+            )
+        if not np.all(bins_pkt[:-1] <= bins_pkt[1:]):
+            raise ValueError("The bin edges are not sorted")
+        maxima_pkt = np.round(maxima_pkt, decimals=decimals, out=maxima_pkt)
+        bins_pkt = np.round(bins_pkt, decimals=decimals, out=bins_pkt)
+        valid_bins = np.isin(bins_pkt, maxima_pkt)
+        if np.count_nonzero(valid_bins) != len(maxima_pkt):
+            raise ValueError(
+                "The number of valid bins ({}) is not equal to the number of"
+                " free-energy maxima"
+                " ({})".format(np.count_nonzero(valid_bins), len(maxima_pkt))
+            )
+        first_valid = np.argmax(valid_bins) - 1
+        if (
+            args.cmp == cmp_fe
+            and args.time != 0  # At t=0 all displacements are zero.
+            and first_valid >= 0
+            and np.isfinite(md_at_const_time_pkt[first_valid])
+        ):
+            raise ValueError("A populated bin was marked as invalid.")
+
+        # Store data in list.
+        ydata[pkp_col_ix][pkt_ix][sim_ix] = minima[pkp_col_ix][pkt_ix][sim_ix]
+        ydata[1][pkt_ix][sim_ix] = md_at_const_time_pkt[valid_bins]
+        ydata[2][pkt_ix][sim_ix] = msd_at_const_time_pkt[valid_bins]
+del maxima
+
+
+print("Discarding free-energy minima whose prominence is too low...")
+prom_min = leap.misc.e_kin(args.prob_thresh)
+prominences = deepcopy(minima[pkm_col_ix])
+n_pks_max = [0 for prom_pkt in prominences]
+for col_ix, yd_col in enumerate(ydata):
+    for pkt_ix, yd_pkt in enumerate(yd_col):
+        for sim_ix, yd_sim in enumerate(yd_pkt):
+            valid = prominences[pkt_ix][sim_ix] >= prom_min
+            ydata[col_ix][pkt_ix][sim_ix] = yd_sim[valid]
+            n_pks_max[pkt_ix] = max(n_pks_max[pkt_ix], np.count_nonzero(valid))
+del minima, prominences
+
+
+print("Clustering peak positions...")
+(
+    ydata,
+    clstr_ix,
+    linkage_matrices,
+    n_clstrs,
+    n_pks_per_sim,
+    clstr_dist_thresh,
+) = leap.clstr.peak_pos(
+    ydata, pkp_col_ix, return_dist_thresh=True, method=clstr_dist_method
+)
+clstr_ix_unq = [np.unique(clstr_ix_pkt) for clstr_ix_pkt in clstr_ix]
+
+# Sort clusters by ascending average peak position and get cluster
+# boundaries.
+clstr_bounds = [None for clstr_ix_pkt in clstr_ix]
+for pkt_ix, clstr_ix_pkt in enumerate(clstr_ix):
+    _clstr_dists, clstr_ix[pkt_ix], bounds = leap.clstr.dists_succ(
+        ydata[pkp_col_ix][pkt_ix],
+        clstr_ix_pkt,
+        method=clstr_dist_method,
+        return_ix=True,
+        return_bounds=True,
+    )
+    clstr_bounds[pkt_ix] = np.append(bounds, bulk_start)
+
+if np.any(n_clstrs < n_pks_max):
+    warnings.warn(
+        "Any `n_clstrs` ({}) < `n_pks_max` ({}).  This means different"
+        " peaks of the same simulation were assigned to the same cluster."
+        "  Try to decrease the threshold distance"
+        " ({})".format(n_clstrs, n_pks_max, clstr_dist_thresh),
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+xdata = [None for n_pks_per_sim_pkt in n_pks_per_sim]
+for pkt_ix, n_pks_per_sim_pkt in enumerate(n_pks_per_sim):
+    if np.max(n_pks_per_sim_pkt) != n_pks_max[pkt_ix]:
+        raise ValueError(
+            "`np.max(n_pks_per_sim[{}])` ({}) != `n_pks_max[{}]` ({}).  This"
+            " should not have happened".format(
+                pkt_ix, np.max(n_pks_per_sim_pkt), pkt_ix, n_pks_max[pkt_ix]
+            )
+        )
+    xdata[pkt_ix] = [
+        Sims.surfqs[sim_ix]
+        for sim_ix, n_pks_sim in enumerate(n_pks_per_sim_pkt)
+        for _ in range(n_pks_sim)
+    ]
+    xdata[pkt_ix] = np.array(xdata[pkt_ix])
+
+
+print("Creating plot(s)...")
+n_clstrs_plot = np.max(n_clstrs)
+if args.n_clusters is not None:
+    n_clstrs_plot = min(n_clstrs_plot, args.n_clusters)
+if n_clstrs_plot <= 0:
+    raise ValueError("`n_clstrs_plot` ({}) <= 0".format(n_clstrs_plot))
+
+if args.cmp in ("NBT", "OBT", "OE"):
+    legend_title = (
+        "$" + leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + "$" + ", "
+    )
+else:
+    legend_title = leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + ", "
+legend_title += (
+    r"$\Delta t = %.1f$ ns" % args.time
+    + "\n"
+    + r"$n_{EO} = %d$, " % Sims.O_per_chain[0]
+    + r"$r = %.2f$" % Sims.Li_O_ratios[0]
+    + "\n"
+    + r"$F_{"
+    + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp_fe]
+    + r"}$ Minima"
+)
+legend_title_suffix = " Positions / nm"
+n_legend_handles_comb = sum(min(n_cl, n_clstrs_plot) for n_cl in n_clstrs)
+n_legend_cols_comb = min(3, 1 + n_legend_handles_comb // (2 + 1))
+legend_locs_sep = tuple("best" for col_ix in range(n_data))
+legend_locs_comb = tuple("best" for col_ix in range(n_data))
+if len(legend_locs_sep) != n_data:
+    raise ValueError(
+        "`len(legend_locs_sep)` ({}) != `n_data`"
+        " ({})".format(len(legend_locs_sep), n_data)
+    )
+if len(legend_locs_comb) != n_data:
+    raise ValueError(
+        "`len(legend_locs_comb)` ({}) != `n_data`"
+        " ({})".format(len(legend_locs_comb), n_data)
+    )
+
+xlabel_sep = r"Surface Charge $\sigma_s$ / $e$/nm$^2$"
+xlabel_comb = r"Surface Charge $|\sigma_s|$ / $e$/nm$^2$"
+xlim = np.array([-0.1, 1.1])
+
+# 1) Free-energy minima positions (distance to electrode).
+ylabels = ["Distance to Electrode / nm"]
+# 2) Mean displacements.
+ylabel = r"$\langle \Delta "
+if args.msd_component == "xy":
+    ylabel += r"%s \rangle" % args.msd_component[0]
+    ylabel += r"+ \langle \Delta %s" % args.msd_component[1]
+elif args.msd_component == "z":
+    ylabel += r"%s" % args.msd_component
+else:
+    raise ValueError(
+        "Unknown --msd-component: '{}'".format(args.msd_component)
+    )
+ylabel += r" \rangle$ / nm"
+ylabels.append(ylabel)
+# 3) Displacement variances.
+ylabel = r"Var$[\Delta "
+if args.msd_component == "xy":
+    ylabel += r"\mathbf{r}_{%s}" % args.msd_component
+elif args.msd_component == "z":
+    ylabel += r"%s" % args.msd_component
+else:
+    raise ValueError(
+        "Unknown --msd-component: '{}'".format(args.msd_component)
+    )
+ylabel += r"]$ / nm$^2$"
+ylabels.append(ylabel)
+if len(ylabels) != n_data:
+    raise ValueError(
+        "`len(ylabels)` ({}) != `n_data` ({})".format(len(ylabels), n_data)
+    )
+
+logy = (  # Whether to use log scale for the y-axis.
+    False,  # Free-energy minima positions (distance to electrode).
+    False,  # Mean displacements.
+    True,  # Displacement variances.
+)
+if len(logy) != n_data:
+    raise ValueError(
+        "`len(logy)` ({}) != `n_data` ({})".format(len(logy), n_data)
+    )
+
+if args.common_ylim:
+    ylims = [
+        (0, 3.6),  # Free-energy minima positions.
+        (None, None),  # Mean displacements.
+        (None, None),  # Displacement variances.
+    ]
+else:
+    ylims = tuple((None, None) for col_ix in range(n_data))
+if len(ylims) != n_data:
+    raise ValueError(
+        "`len(ylims)` ({}) != `n_data` ({})".format(len(ylims), n_data)
+    )
+
+linestyles_comb = ("solid", "dashed")
+if len(linestyles_comb) != len(pk_pos_types):
+    raise ValueError(
+        "`len(linestyles_comb)` ({}) != `len(pk_pos_types)`"
+        " ({})".format(len(linestyles_comb), len(pk_pos_types))
+    )
+markers = ("<", ">")
+if len(markers) != len(pk_pos_types):
+    raise ValueError(
+        "`len(markers)` ({}) != `len(pk_pos_types)`"
+        " ({})".format(len(markers), len(pk_pos_types))
+    )
+
+cmap = plt.get_cmap()
+c_vals_sep = np.arange(n_clstrs_plot)
+c_norm_sep = n_clstrs_plot - 1
+c_vals_sep_normed = c_vals_sep / c_norm_sep
+colors_sep = cmap(c_vals_sep_normed)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    for col_ix, yd_col in enumerate(ydata):
+        # Peaks at left and right electrode combined in one plot.
+        fig_comb, ax_comb = plt.subplots(clear=True)
+
+        for pkt_ix, pkp_type in enumerate(pk_pos_types):
+            yd_pkt = yd_col[pkt_ix]
+
+            if pkp_type == "left":
+                xdata_fac = 1
+            elif pkp_type == "right":
+                xdata_fac = -1
+            else:
+                raise ValueError("Unknown `pkp_type`: '{}'".format(pkp_type))
+
+            # Peaks at left and right electrode in separate plots.
+            fig_sep, ax_sep = plt.subplots(clear=True)
+            ax_sep.set_prop_cycle(color=colors_sep)
+
+            c_vals_comb = c_vals_sep + 0.5 * pkt_ix
+            c_norm_comb = c_norm_sep + 0.5 * (len(pk_pos_types) - 1)
+            c_vals_comb_normed = c_vals_comb / c_norm_comb
+            colors_comb = cmap(c_vals_comb_normed)
+            ax_comb.set_prop_cycle(color=colors_comb)
+
+            for cix_pkt in clstr_ix_unq[pkt_ix]:
+                if cix_pkt >= n_clstrs_plot:
+                    break
+
+                valid = clstr_ix[pkt_ix] == cix_pkt
+                if not np.any(valid):
+                    raise ValueError(
+                        "No valid peaks for peak type '{}' and cluster index"
+                        " {}".format(pkp_type, cix_pkt)
+                    )
+
+                if pkp_type == "left":
+                    label_sep = r"$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt]
+                    label_comb = r"$+, " + label_sep[1:]
+                elif pkp_type == "right":
+                    label_sep = r"$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt]
+                    label_comb = r"$-, " + label_sep[1:]
+                else:
+                    raise ValueError(
+                        "Unknown `pkp_type`: '{}'".format(pkp_type)
+                    )
+                ax_sep.plot(
+                    xdata_fac * xdata[pkt_ix][valid],
+                    yd_pkt[valid],
+                    linestyle="solid",
+                    marker=markers[pkt_ix],
+                    label=label_sep,
+                )
+                ax_comb.plot(
+                    xdata[pkt_ix][valid],
+                    yd_pkt[valid],
+                    linestyle=linestyles_comb[pkt_ix],
+                    marker=markers[pkt_ix],
+                    label=label_comb,
+                )
+
+            legend_title_sep = legend_title
+            if col_ix == 0:
+                # Remove compound and lag time from legend title.
+                legend_title_sep = legend_title_sep.split("\n")[1:]
+                legend_title_sep = "\n".join(legend_title_sep)
+            if logy[col_ix]:
+                ax_sep.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax_sep.set(
+                xlabel=xlabel_sep,
+                ylabel=ylabels[col_ix],
+                xlim=xdata_fac * xlim,
+                ylim=ylims[col_ix],
+            )
+            equalize_xticks(ax_sep)
+            if not logy[col_ix]:
+                equalize_yticks(ax_sep)
+            legend_sep = ax_sep.legend(
+                title=legend_title_sep + legend_title_suffix,
+                ncol=2,
+                loc=legend_locs_sep[col_ix],
+                **mdtplt.LEGEND_KWARGS_XSMALL,
+            )
+            legend_sep.get_title().set_multialignment("center")
+            pdf.savefig(fig_sep)
+            plt.close(fig_sep)
+
+        legend_title_comb = legend_title
+        if col_ix == 0:
+            # Remove compound and lag time from legend title.
+            legend_title_comb = legend_title_comb.split("\n")[1:]
+            legend_title_comb = "\n".join(legend_title_comb)
+        if logy[col_ix]:
+            ax_comb.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax_comb.set(
+            xlabel=xlabel_comb,
+            ylabel=ylabels[col_ix],
+            xlim=xlim,
+            ylim=ylims[col_ix],
+        )
+        equalize_xticks(ax_comb)
+        if not logy[col_ix]:
+            equalize_yticks(ax_comb)
+        legend_comb = ax_comb.legend(
+            title=legend_title_comb + legend_title_suffix,
+            ncol=n_legend_cols_comb,
+            loc=legend_locs_comb[col_ix],
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend_comb.get_title().set_multialignment("center")
+        pdf.savefig(fig_comb)
+        plt.close(fig_comb)
+
+    # Plot clustering results.
+    for pkt_ix, pkp_type in enumerate(pk_pos_types):
+        # Remove compound and lag time from legend title.
+        legend_title_clstrng = legend_title.split("\n")[1:]
+        legend_title_clstrng = "\n".join(legend_title_clstrng)
+        if pkp_type == "left":
+            xdata_fac = 1
+            legend_title_clstrng = r"$+|\sigma_s|$, " + legend_title_clstrng
+        elif pkp_type == "right":
+            xdata_fac = -1
+            legend_title_clstrng = r"$-|\sigma_s|$, " + legend_title_clstrng
+        else:
+            raise ValueError("Unknown `pkp_type`: '{}'".format(pkp_type))
+        cmap_norm = plt.Normalize(vmin=0, vmax=np.max(n_clstrs) - 1)
+
+        # Dendrogram.
+        fig, ax = plt.subplots(clear=True)
+        dendrogram(
+            linkage_matrices[pkt_ix],
+            ax=ax,
+            distance_sort="ascending",
+            color_threshold=clstr_dist_thresh[pkt_ix],
+        )
+        ax.axhline(
+            clstr_dist_thresh[pkt_ix],
+            color="tab:gray",
+            linestyle="dashed",
+            label=r"Threshold $%.2f$ nm" % clstr_dist_thresh[pkt_ix],
+        )
+        ax.set(
+            xlabel="Peak Number",
+            ylabel="Peak Distance / nm",
+            ylim=(0, ylims[pkp_col_ix][-1]),
+        )
+        legend = ax.legend(
+            title=legend_title_clstrng,
+            loc="best",
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+        # Scatter plot: Peak Positions vs. Peak Positions.
+        fig, ax = plt.subplots(clear=True)
+        for cix_pkt in clstr_ix_unq[pkt_ix]:
+            if cix_pkt >= n_clstrs_plot:
+                break
+            valid = clstr_ix[pkt_ix] == cix_pkt
+            if not np.any(valid):
+                raise ValueError(
+                    "No valid peaks for peak type '{}' and cluster index"
+                    " {}".format(pkp_type, cix_pkt)
+                )
+            ax.scatter(
+                ydata[pkp_col_ix][pkt_ix][valid],
+                ydata[pkp_col_ix][pkt_ix][valid],
+                color=cmap(cmap_norm(cix_pkt)),
+                marker=markers[pkt_ix],
+                label="$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt],
+            )
+        ax.set(
+            xlabel=ylabels[pkp_col_ix],
+            ylabel=ylabels[pkp_col_ix],
+            xlim=ylims[pkp_col_ix],
+            ylim=ylims[pkp_col_ix],
+        )
+        legend = ax.legend(
+            title=legend_title_clstrng + legend_title_suffix,
+            ncol=2,
+            loc="upper left",
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+        # Scatter plot: Peak Positions vs. `xdata`.
+        fig, ax = plt.subplots(clear=True)
+        for cix_pkt in clstr_ix_unq[pkt_ix]:
+            if cix_pkt >= n_clstrs_plot:
+                break
+            valid = clstr_ix[pkt_ix] == cix_pkt
+            if not np.any(valid):
+                raise ValueError(
+                    "No valid peaks for peak type '{}' and cluster index"
+                    " {}".format(pkp_type, cix_pkt)
+                )
+            ax.scatter(
+                xdata_fac * xdata[pkt_ix][valid],
+                ydata[pkp_col_ix][pkt_ix][valid],
+                color=cmap(cmap_norm(cix_pkt)),
+                marker=markers[pkt_ix],
+                label="$<%.2f$" % clstr_bounds[pkt_ix][cix_pkt],
+            )
+        ax.set(
+            xlabel=xlabel_sep,
+            ylabel=ylabels[pkp_col_ix],
+            xlim=xdata_fac * xlim,
+            ylim=ylims[pkp_col_ix],
+        )
+        equalize_xticks(ax)
+        equalize_yticks(ax)
+        lgd_title = legend_title.split("\n")[1:]
+        lgd_title = "\n".join(lgd_title)
+        legend = ax.legend(
+            title=lgd_title + legend_title_suffix,
+            ncol=2,
+            loc=legend_locs_sep[pkp_col_ix],
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+
+"""
+Plot the x-, y- and z-component of the mean displacement and the
+displacement variance as function of the initial particle position at a
+constant diffusion time for a single simulation.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+
+# Third-party libraries
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import MaxNLocator
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the x-, y- and z-component of the mean displacement and the"
+        " displacement variance as function of the initial particle position"
+        " at a constant diffusion time for a single simulation."
+    )
+)
+parser.add_argument(
+    "--system",
+    type=str,
+    required=True,
+    help="Name of the simulated system, e.g. lintf2_g1_20-1_gra_q1_sc80.",
+)
+parser.add_argument(
+    "--settings",
+    type=str,
+    required=False,
+    default="pr_nvt423_nh",
+    help=(
+        "String describing the used simulation settings.  Default:"
+        " %(default)s."
+    ),
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=False,
+    default="Li",
+    choices=("Li", "NTf2", "ether", "NBT", "OBT", "OE"),
+    help="Compound.  Default: %(default)s",
+)
+parser.add_argument(
+    "--time",
+    type=float,
+    required=False,
+    default=1000,
+    help=(
+        "Diffusion time in ps for which to plot the displacements as function"
+        " of the initial particle position.  If no data are present at the"
+        " given diffusion time, the next nearest diffusion time for which data"
+        " are present is used.  Default: %(default)s"
+    ),
+)
+args = parser.parse_args()
+
+analysis = "msd_layer"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+ana_path = os.path.join(analysis, analysis + analysis_suffix)
+tool = "mdt"  # Analysis software.
+outfile = (
+    args.settings
+    + "_"
+    + args.system
+    + "_"
+    + args.cmp
+    + "_displvar_cross_section_xyz_"
+    + "%.0fps" % args.time
+    + ".pdf"
+)
+
+
+print("Creating Simulation instance(s)...")
+if "_gra_" in args.system:
+    surfq = leap.simulation.get_surfq(args.system)
+    top_path = "q%g" % surfq
+else:
+    surfq = None
+    top_path = "bulk"
+set_pat = "[0-9][0-9]_" + args.settings + "_" + args.system
+Sim = leap.simulation.get_sim(args.system, set_pat, top_path)
+
+
+print("Reading data...")
+args.time /= 1e3  # ps -> ns.
+dimensions = ("x", "y", "z")
+md_at_const_time = [None for dim in dimensions]
+msd_at_const_time = [None for dim in dimensions]
+for dim_ix, dim in enumerate(dimensions):
+    (
+        times_dim,
+        bins_dim,
+        md_data,
+        msd_data,
+    ) = leap.simulation.read_displvar_single(Sim, args.cmp, dim)
+    if dim_ix == 0:
+        times, bins = times_dim, bins_dim
+    else:
+        if bins_dim.shape != bins.shape:
+            raise ValueError(
+                "The input files do not contain the same number of bins"
+            )
+        if not np.allclose(bins_dim, bins, atol=0):
+            raise ValueError(
+                "The bin edges are not the same in all input files"
+            )
+        if times_dim.shape != times.shape:
+            raise ValueError(
+                "The input files do not contain the same number of lag times"
+            )
+        if not np.allclose(times_dim, times, atol=0):
+            raise ValueError(
+                "The lag times are not the same in all input files"
+            )
+    time, tix = mdt.nph.find_nearest(times, args.time, return_index=True)
+    md_at_const_time[dim_ix] = md_data[tix]
+    msd_at_const_time[dim_ix] = msd_data[tix]
+bin_mids = bins[1:] - np.diff(bins) / 2
+del times, times_dim, bins_dim, md_data, msd_data
+
+
+print("Creating plot(s)...")
+Elctrd = leap.simulation.Electrode()
+elctrd_thk = Elctrd.ELCTRD_THK / 10  # A -> nm
+box_z = Sim.box[2] / 10  # Angstrom -> nm.
+
+xlabel = r"Initial Position $z(t_0)$ / nm"
+xlim = (0, box_z)
+
+if args.cmp in ("NBT", "OBT", "OE"):
+    legend_title = (
+        "$" + leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + "$" + ", "
+    )
+else:
+    legend_title = leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + ", "
+legend_title += r"$\Delta t = %.1f$ ns" % time + "\n"
+if surfq is not None:
+    legend_title += r"$\sigma_s = \pm %.2f$ $e$/nm$^2$" % surfq + "\n"
+legend_title += (
+    r"$n_{EO} = %d$, " % Sim.O_per_chain + r"$r = %.4f$" % Sim.Li_O_ratio
+)
+n_legend_cols = 3
+
+markers = ("s", "D", "o")
+if len(markers) != len(dimensions):
+    raise ValueError(
+        "`len(markers)` ({}) != `len(dimensions)`"
+        " ({})".format(len(markers), len(dimensions))
+    )
+
+height_ratios = (0.2, 1)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot mean displacement vs initial position.
+    ylabel = r"$\langle \Delta\mathbf{r} \rangle$ / nm"
+    fig, axs = plt.subplots(
+        clear=True,
+        nrows=2,
+        sharex=True,
+        gridspec_kw={"height_ratios": height_ratios},
+    )
+    fig.set_figheight(fig.get_figheight() * sum(height_ratios))
+    ax_profile, ax = axs
+    leap.plot.profile(ax_profile, Sim=Sim, free_en=True)
+    ax.axhline(y=0, color="black")
+    if surfq is not None:
+        leap.plot.elctrds(
+            ax, offset_left=elctrd_thk, offset_right=box_z - elctrd_thk
+        )
+    md_min, md_max = 0, 0
+    for dim_ix, dim in enumerate(dimensions):
+        ax.plot(
+            bin_mids,
+            md_at_const_time[dim_ix],
+            label="$" + dim + "$",
+            marker=markers[dim_ix],
+        )
+        md_min = min(md_min, np.nanmin(md_at_const_time[dim_ix]))
+        md_max = max(md_max, np.nanmax(md_at_const_time[dim_ix]))
+    leap.plot.bins(ax, bins=bins)
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+    ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+    if md_max >= abs(md_min):
+        legend_loc = "upper center"
+    else:
+        legend_loc = "lower center"
+    legend = ax.legend(
+        title=legend_title,
+        loc=legend_loc,
+        ncol=n_legend_cols,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot displacement variance vs initial position.
+    ylabel = r"Var$[\Delta\mathbf{r}]$ / nm$^2$"
+    fig, axs = plt.subplots(
+        clear=True,
+        nrows=2,
+        sharex=True,
+        gridspec_kw={"height_ratios": height_ratios},
+    )
+    fig.set_figheight(fig.get_figheight() * sum(height_ratios))
+    ax_profile, ax = axs
+    leap.plot.profile(ax_profile, Sim=Sim, free_en=True)
+    if surfq is not None:
+        leap.plot.elctrds(
+            ax, offset_left=elctrd_thk, offset_right=box_z - elctrd_thk
+        )
+    for dim_ix, dim in enumerate(dimensions):
+        ax.plot(
+            bin_mids,
+            msd_at_const_time[dim_ix],
+            label="$" + dim + "$",
+            marker=markers[dim_ix],
+        )
+    leap.plot.bins(ax, bins=bins)
+    ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+    ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+    legend = ax.legend(
+        title=legend_title,
+        loc="lower center",
+        ncol=n_legend_cols,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.sh
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+settings="pr_nvt423_nh"
+top_path="${HOME}/ownCloud/WWU_Münster/Promotion/Simulationen/results/lintf2_peo/walls"
+cmp=Li
+flags=()
+
+########################################################################
+# Information and Usage Functions                                      #
+########################################################################
+
+information() {
+    echo "Loop over all surface-simulation directories and run the"
+    echo "Python script plot_displvar_cross_section_xyz_at_const_time.py"
+    echo "to plot the x-, y- and z-component of the mean displacement"
+    echo "and the displacement variance as function of the initial"
+    echo "particle position at a constant diffusion time."
+}
+
+usage() {
+    echo
+    echo "Usage:"
+    echo
+    echo "Optional arguments:"
+    echo "  -h    Show this help message and exit."
+    echo "  -e    String describing the used simulation settings."
+    echo "        Default: '${settings}'."
+    echo "  -t    Top-level simulation path containing all surface"
+    echo "        simulations.  Default: '${top_path}'."
+    echo "  -c    The compound for which to plot the displacements."
+    echo "        Default: '${cmp}'"
+    echo "  -f    Addtional options (besides --system, --settings and --cmp)"
+    echo "        to parse to"
+    echo "        'plot_displvar_cross_section_xyz_at_const_time.py' as one"
+    echo "        long, enquoted string.  See there for possible options."
+    echo "        Default: '${flags[*]}'"
+}
+
+########################################################################
+# Argument Parsing                                                     #
+########################################################################
+
+while getopts he:t:c:f: option; do
+    case ${option} in
+        # Optional arguments.
+        h)
+            information
+            usage
+            exit 0
+            ;;
+        e)
+            settings=${OPTARG}
+            ;;
+        t)
+            top_path=${OPTARG}
+            ;;
+        c)
+            cmp=${OPTARG}
+            ;;
+        f)
+            # See https://github.com/koalaman/shellcheck/wiki/SC2086#exceptions
+            # and https://github.com/koalaman/shellcheck/wiki/SC2206
+            # shellcheck disable=SC2206
+            flags=(${OPTARG})
+            ;;
+        # Handling of invalid options or missing arguments.
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -d ${top_path} ]]; then
+    echo "ERROR: No such directory: '${top_path}'"
+    exit 1
+fi
+
+########################################################################
+# Main Part                                                            #
+########################################################################
+
+cwd=$(pwd) # Current working directory.
+
+script_dir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+project_root=$(readlink -e "${script_dir}/../../../.." || exit)
+py_exe=".venv/bin/python3"
+py_exe="${project_root}/${py_exe}"
+py_script=$(readlink -e "${script_dir}/plot_displvar_cross_section_xyz_at_const_time.py" || exit)
+if [[ ! -d ${script_dir} ]]; then
+    echo "ERROR: No such directory '${script_dir}'"
+    exit 1
+fi
+if [[ ! -d ${project_root} ]]; then
+    echo "ERROR: No such directory '${project_root}'"
+    exit 1
+fi
+if [[ ! -x ${py_exe} ]]; then
+    echo "ERROR: No such executable '${py_exe}'"
+    exit 1
+fi
+if [[ ! -f ${py_script} ]]; then
+    echo "ERROR: No such file '${py_script}'"
+    exit 1
+fi
+
+analysis="msd_layer"
+tool="mdt"
+
+cd "${top_path}" || exit
+for surfq in q[0-9]*; do
+    echo
+    echo "============================================================="
+    echo "${surfq}"
+    if [[ ! -d ${surfq} ]]; then
+        echo "WARNING: No such directory: '${surfq}'"
+        continue
+    fi
+    cd "${surfq}" || exit
+
+    for system in lintf2_[gp]*[0-9]*_[0-9]*-[0-9]*_gra_"${surfq}"_sc80; do
+        echo
+        echo "${system}"
+        if [[ ! -d ${system} ]]; then
+            echo "WARNING: No such directory: '${system}'"
+            continue
+        fi
+        cd "${system}" || exit
+
+        sim_dir="${settings}_${system}"
+        if [[ ${system} != *_gra_* ]]; then
+            sim_dir="07_${sim_dir}"
+        elif [[ ${system} == *_gra_q0_* ]]; then
+            sim_dir="09_${sim_dir}"
+        else
+            sim_dir="01_${sim_dir}"
+        fi
+        if [[ ! -d ${sim_dir} ]]; then
+            echo "WARNING: No such directory: '${sim_dir}'"
+            cd ../ || exit
+            continue
+        fi
+        cd "${sim_dir}" || exit
+
+        ana_dir="ana_${settings}_${system}/${tool}/${analysis}"
+        if [[ ! -d ${ana_dir} ]]; then
+            echo "WARNING: No such directory: '${ana_dir}'"
+            cd ../../ || exit
+            continue
+        fi
+        cd "${ana_dir}" || exit
+
+        ana_sub_dir="${analysis}_${cmp}"
+        if [[ ! -d ${ana_sub_dir} ]]; then
+            echo "WARNING: No such directory: '${ana_sub_dir}'"
+            cd ../../../../../ || exit
+            continue
+        fi
+        cd "${ana_sub_dir}" || exit
+
+        # shellcheck disable=SC2048,SC2086
+        ${py_exe} "${py_script}" \
+            --system "${system}" \
+            --settings "${settings}" \
+            --cmp "${cmp}" \
+            ${flags[*]} ||
+            exit
+
+        cd ../../../../../../ || exit
+    done
+
+    cd ../ || exit
+    echo "============================================================="
+done
+cd "${cwd}" || exit
+
+echo
+echo "Done"

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the mean displacement and the displacement variance as function of
+the diffusion time for various bins for a single simulation.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+
+# Third-party libraries
+import matplotlib as mpl
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+from scipy.optimize import curve_fit
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+# Circumvent "OverflowError: Exceeded cell block limit in Agg."
+# https://github.com/matplotlib/matplotlib/issues/5907#issuecomment-179001811
+mpl.rcParams["agg.path.chunksize"] = 10000
+
+
+def fit_msd_slope1(xdata, ydata, start=0, stop=-1):
+    """
+    Fit the logarithmic `ydata` as function of the logarithmic `xdata`
+    with a straight line with slope 1.
+
+    The obtained fit parameters are converted from the parameters of a
+    straight line to the parameters of the corresponding power law.
+    """
+    xdata = np.log(xdata[start:stop])
+    ydata = np.log(ydata[start:stop])
+    valid = np.isfinite(xdata) & np.isfinite(ydata)
+    if np.count_nonzero(valid) < 2:
+        raise ValueError("The fitting requires at least two valid data points")
+    xdata, ydata = xdata[valid], ydata[valid]
+    popt, pcov = curve_fit(
+        f=lambda x, c: leap.misc.straight_line(x=x, m=1, c=c),
+        xdata=xdata,
+        ydata=ydata,
+        p0=xdata[0],
+    )
+    perr = np.sqrt(np.diag(pcov))
+    # Convert straight-line parameters to the corresponding power-law
+    # parameters.
+    popt = np.array([np.exp(popt[0])])
+    # Propagation of uncertainty.
+    # Std[exp(A)] = |exp(A)| * Std[A]
+    perr = np.array([np.abs(popt[0]) * perr[0]])
+    return popt, perr
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the mean displacement and the displacement variance as function"
+        " of the diffusion time for various bins for a single simulation."
+    )
+)
+parser.add_argument(
+    "--system",
+    type=str,
+    required=True,
+    help="Name of the simulated system, e.g. lintf2_g1_20-1_gra_q1_sc80.",
+)
+parser.add_argument(
+    "--settings",
+    type=str,
+    required=False,
+    default="pr_nvt423_nh",
+    help=(
+        "String describing the used simulation settings.  Default:"
+        " %(default)s."
+    ),
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=False,
+    default="Li",
+    choices=("Li", "NTf2", "ether", "NBT", "OBT", "OE"),
+    help="Compound.  Default: %(default)s",
+)
+parser.add_argument(
+    "--msd-component",
+    type=str,
+    required=False,
+    default="z",
+    choices=("x", "y", "z"),
+    help="The MSD component to use for the analysis.  Default: %(default)s",
+)
+args = parser.parse_args()
+
+analysis = "msd_layer"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+ana_path = os.path.join(analysis, analysis + analysis_suffix)
+tool = "mdt"  # Analysis software.
+outfile = (
+    args.settings
+    + "_"
+    + args.system
+    + "_"
+    + args.cmp
+    + "_displvar"
+    + args.msd_component
+    + "_layer.pdf"
+)
+
+
+print("Creating Simulation instance(s)...")
+if "_gra_" in args.system:
+    surfq = leap.simulation.get_surfq(args.system)
+    top_path = "q%g" % surfq
+else:
+    surfq = None
+    top_path = "bulk"
+set_pat = "[0-9][0-9]_" + args.settings + "_" + args.system
+Sim = leap.simulation.get_sim(args.system, set_pat, top_path)
+
+
+print("Reading data...")
+times, bins, md_data, msd_data = leap.simulation.read_displvar_single(
+    Sim, args.cmp, args.msd_component
+)
+# Discard fist lag time of zero, because plots use log scale.
+times = times[1:]
+md_data = md_data[1:]
+msd_data = msd_data[1:]
+
+
+print("Fitting straight line...")
+bin_nums = np.arange(1, len(bins))
+bin_ix = len(bin_nums) // 2 - 1
+fit_start, fit_stop = int(np.sqrt(len(times))), int(0.99 * len(times))
+popt, perr = fit_msd_slope1(
+    times, msd_data[:, bin_ix], start=fit_start, stop=fit_stop
+)
+
+
+print("Creating plot(s)...")
+xlabel = r"Diffusion Time $\Delta t$ / ns"
+xlim = (times[0], times[-1])
+
+if args.cmp in ("NBT", "OBT", "OE"):
+    legend_title = (
+        "$" + leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + "$" + ", "
+    )
+else:
+    legend_title = leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + ", "
+if surfq is not None:
+    legend_title += r"$\sigma_s = \pm %.2f$ $e$/nm$^2$" % surfq + "\n"
+legend_title += (
+    r"$n_{EO} = %d$, " % Sim.O_per_chain
+    + r"$r = %.4f$" % Sim.Li_O_ratio
+    + "\n"
+    + "Bin Number"
+)
+
+invalid = np.all(np.isnan(msd_data), axis=0)
+n_bins_valid = len(invalid) - np.count_nonzero(invalid)
+if n_bins_valid == 0:
+    raise ValueError("The displacements in all bins are NaN")
+cmap = plt.get_cmap()
+c_vals = np.arange(n_bins_valid)
+c_norm = max(1, n_bins_valid - 1)
+c_vals_normed = c_vals / c_norm
+colors = cmap(c_vals_normed)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot mean displacement vs time.
+    ylabel = (
+        r"$\langle \Delta %s (\Delta t) \rangle$ / nm" % args.msd_component
+    )
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    ax.axhline(y=0, color="black")
+    md_min, md_max = 0, 0
+    for bix, bin_num in enumerate(bin_nums):
+        if np.all(np.isnan(md_data[:, bix])):
+            continue
+        # Discard last data points, because they are quite noisy and
+        # tend to distort the automatic y axis scaling.
+        ax.plot(
+            times[:fit_stop],
+            md_data[:, bix][:fit_stop],
+            label=r"$%d$" % bin_num,
+            alpha=leap.plot.ALPHA,
+            rasterized=True,
+        )
+        md_min = min(md_min, np.nanmin(md_data[:, bix][:fit_stop]))
+        md_max = max(md_max, np.nanmax(md_data[:, bix][:fit_stop]))
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+    if md_max >= abs(md_min):
+        legend_loc = "upper left"
+    else:
+        legend_loc = "lower left"
+    legend = ax.legend(
+        title=legend_title,
+        loc=legend_loc,
+        ncol=1 + len(bin_nums) // 4,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot displacement variance vs time.
+    ylabel = r"Var$[\Delta %s (\Delta t)]$ / nm$^2$" % args.msd_component
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    for bix, bin_num in enumerate(bin_nums):
+        if np.all(np.isnan(msd_data[:, bix])):
+            continue
+        # Discard last data points, because they are quite noisy and
+        # tend to distort the automatic y axis scaling.
+        ax.plot(
+            times[:fit_stop],
+            msd_data[:, bix][:fit_stop],
+            label=r"$%d$" % bin_num,
+            alpha=leap.plot.ALPHA,
+            rasterized=True,
+        )
+    ax.plot(
+        times[fit_start:fit_stop],
+        leap.misc.power_law(times[fit_start:fit_stop], m=1, c=popt[0]),
+        label=r"$\propto \Delta t$",
+        color="black",
+        linestyle="dashed",
+    )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+    legend = ax.legend(
+        title=legend_title,
+        loc="upper left",
+        ncol=1 + len(bin_nums) // 6,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.sh
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+settings="pr_nvt423_nh"
+top_path="${HOME}/ownCloud/WWU_Münster/Promotion/Simulationen/results/lintf2_peo/walls"
+cmp=Li
+
+########################################################################
+# Information and Usage Functions                                      #
+########################################################################
+
+information() {
+    echo "Loop over all surface-simulation directories and run the"
+    echo "Python script plot_displvar_layer_vs_time.py to plot the mean"
+    echo "displacement and the displacement variance as function of the"
+    echo "diffusion time for various bins."
+}
+
+usage() {
+    echo
+    echo "Usage:"
+    echo
+    echo "Optional arguments:"
+    echo "  -h    Show this help message and exit."
+    echo "  -e    String describing the used simulation settings."
+    echo "        Default: '${settings}'."
+    echo "  -t    Top-level simulation path containing all surface"
+    echo "        simulations.  Default: '${top_path}'."
+    echo "  -c    The compound for which to plot the displacements."
+    echo "        Default: '${cmp}'"
+}
+
+########################################################################
+# Argument Parsing                                                     #
+########################################################################
+
+while getopts he:t:c: option; do
+    case ${option} in
+        # Optional arguments.
+        h)
+            information
+            usage
+            exit 0
+            ;;
+        e)
+            settings=${OPTARG}
+            ;;
+        t)
+            top_path=${OPTARG}
+            ;;
+        c)
+            cmp=${OPTARG}
+            ;;
+        # Handling of invalid options or missing arguments.
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -d ${top_path} ]]; then
+    echo "ERROR: No such directory: '${top_path}'"
+    exit 1
+fi
+
+########################################################################
+# Main Part                                                            #
+########################################################################
+
+cwd=$(pwd) # Current working directory.
+
+script_dir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+project_root=$(readlink -e "${script_dir}/../../../.." || exit)
+py_exe=".venv/bin/python3"
+py_exe="${project_root}/${py_exe}"
+py_script=$(readlink -e "${script_dir}/plot_displvar_layer_vs_time.py" || exit)
+if [[ ! -d ${script_dir} ]]; then
+    echo "ERROR: No such directory '${script_dir}'"
+    exit 1
+fi
+if [[ ! -d ${project_root} ]]; then
+    echo "ERROR: No such directory '${project_root}'"
+    exit 1
+fi
+if [[ ! -x ${py_exe} ]]; then
+    echo "ERROR: No such executable '${py_exe}'"
+    exit 1
+fi
+if [[ ! -f ${py_script} ]]; then
+    echo "ERROR: No such file '${py_script}'"
+    exit 1
+fi
+
+analysis="msd_layer"
+tool="mdt"
+
+cd "${top_path}" || exit
+for surfq in q[0-9]*; do
+    echo
+    echo "============================================================="
+    echo "${surfq}"
+    if [[ ! -d ${surfq} ]]; then
+        echo "WARNING: No such directory: '${surfq}'"
+        continue
+    fi
+    cd "${surfq}" || exit
+
+    for system in lintf2_[gp]*[0-9]*_[0-9]*-[0-9]*_gra_"${surfq}"_sc80; do
+        echo
+        echo "${system}"
+        if [[ ! -d ${system} ]]; then
+            echo "WARNING: No such directory: '${system}'"
+            continue
+        fi
+        cd "${system}" || exit
+
+        sim_dir="${settings}_${system}"
+        if [[ ${system} != *_gra_* ]]; then
+            sim_dir="07_${sim_dir}"
+        elif [[ ${system} == *_gra_q0_* ]]; then
+            sim_dir="09_${sim_dir}"
+        else
+            sim_dir="01_${sim_dir}"
+        fi
+        if [[ ! -d ${sim_dir} ]]; then
+            echo "WARNING: No such directory: '${sim_dir}'"
+            cd ../ || exit
+            continue
+        fi
+        cd "${sim_dir}" || exit
+
+        ana_dir="ana_${settings}_${system}/${tool}/${analysis}"
+        if [[ ! -d ${ana_dir} ]]; then
+            echo "WARNING: No such directory: '${ana_dir}'"
+            cd ../../ || exit
+            continue
+        fi
+        cd "${ana_dir}" || exit
+
+        ana_sub_dir="${analysis}_${cmp}"
+        if [[ ! -d ${ana_sub_dir} ]]; then
+            echo "WARNING: No such directory: '${ana_sub_dir}'"
+            cd ../../../../../ || exit
+            continue
+        fi
+        cd "${ana_sub_dir}" || exit
+
+        for dim in x y z; do
+            ${py_exe} "${py_script}" \
+                --system "${system}" \
+                --settings "${settings}" \
+                --cmp "${cmp}" \
+                --msd-component "${dim}" ||
+                exit
+        done
+
+        cd ../../../../../../ || exit
+    done
+
+    cd ../ || exit
+    echo "============================================================="
+done
+cd "${cwd}" || exit
+
+echo
+echo "Done"

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvarxy_layer_tscaled_vs_time.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvarxy_layer_tscaled_vs_time.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+
+
+"""
+Scale and plot the displacement variance of the lithium ions in the
+first layer at the right (negative) electrode such that it overlaps with
+the corresponding displacement variance in a bulk layer for a single
+simulation.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+
+# Third-party libraries
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib import pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+from scipy.optimize import curve_fit
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def fit_msd_slope1(xdata, ydata, start=0, stop=-1):
+    """
+    Fit the logarithmic `ydata` as function of the logarithmic `xdata`
+    with a straight line with slope 1.
+
+    The obtained fit parameters are converted from the parameters of a
+    straight line to the parameters of the corresponding power law.
+    """
+    xdata = np.log(xdata[start:stop])
+    ydata = np.log(ydata[start:stop])
+    valid = np.isfinite(xdata) & np.isfinite(ydata)
+    if np.count_nonzero(valid) < 2:
+        raise ValueError("The fitting requires at least two valid data points")
+    xdata, ydata = xdata[valid], ydata[valid]
+    popt, pcov = curve_fit(
+        f=lambda x, c: leap.misc.straight_line(x=x, m=1, c=c),
+        xdata=xdata,
+        ydata=ydata,
+        p0=xdata[0],
+    )
+    perr = np.sqrt(np.diag(pcov))
+    # Convert straight-line parameters to the corresponding power-law
+    # parameters.
+    popt = np.array([np.exp(popt[0])])
+    # Propagation of uncertainty.
+    # Std[exp(A)] = |exp(A)| * Std[A]
+    perr = np.array([np.abs(popt[0]) * perr[0]])
+    return popt, perr
+
+
+def fit_msd(xdata, ydata, start=0, stop=-1):
+    """
+    Fit the logarithmic `ydata` as function of the logarithmic `xdata`
+    with a straight line.
+
+    The obtained fit parameters are converted from the parameters of a
+    straight line to the parameters of the corresponding power law.
+    """
+    xdata = np.log(xdata[start:stop])
+    ydata = np.log(ydata[start:stop])
+    valid = np.isfinite(xdata) & np.isfinite(ydata)
+    slope_guess = (ydata[-1] - ydata[0]) / (xdata[-1] - xdata[0])
+    intercept_guess = ydata[0] - slope_guess * xdata[0]
+    if np.count_nonzero(valid) < 2:
+        raise ValueError("The fitting requires at least two valid data points")
+    xdata, ydata = xdata[valid], ydata[valid]
+    popt, pcov = curve_fit(
+        f=leap.misc.straight_line,
+        xdata=xdata,
+        ydata=ydata,
+        p0=(slope_guess, intercept_guess),
+    )
+    perr = np.sqrt(np.diag(pcov))
+    # Convert straight-line parameters to the corresponding power-law
+    # parameters.
+    popt = np.array([popt[0], np.exp(popt[1])])
+    # Propagation of uncertainty.
+    # Std[exp(A)] = |exp(A)| * Std[A]
+    perr = np.array([perr[0], np.abs(popt[1]) * perr[1]])
+    return popt, perr
+
+
+def cost_func(times, msd, msd_ref, t0):
+    r"""
+    Cost function to quantify the overlap between a MSD curve with a
+    reference MSD curve.
+
+    Parameters
+    ----------
+    times, msd, msd_ref : array_like
+        Lag times, corresponding MSD values and corresponding reference
+        MSD values.
+    t0 : scalar
+        Scaling factor to scale the lag times such that the MSD becomes
+        equal to the reference MSD.
+
+    Returns
+    -------
+    cost : scalar
+        A value quantifying the difference of the time-scaled MSD and
+        the reference MSD.
+
+    Notes
+    -----
+    The used cost function is
+
+    .. math::
+
+        f(t_0) = \sum_i
+        \left( \frac{MSD_i^{ref}}{t_i} - t_0 \frac{MSD_i}{t_i} \right)^2
+
+    where the index :math:`i` labels the measured data points.
+
+    See notes in my "sketch book" from 22.01.2021.
+    """
+    times = np.asarray(times)
+    msd = np.asarray(msd)
+    msd_ref = np.asarray(msd_ref)
+
+    cost = msd_ref / times
+    cost -= t0 * msd / times
+    cost **= 2
+    return cost
+
+
+def opt_scaling(times, msd, msd_ref):
+    r"""
+    Calculate the optimal time scaling factor such the MSD has the
+    greatest possible overlap with the reference MSD.
+
+    Parameters
+    ----------
+    times, msd, msd_ref : array_like
+        Lag times, corresponding MSD values and corresponding reference
+        MSD values.
+
+    Returns
+    -------
+    t0 : float
+        The optimal scaling factor.
+
+    Notes
+    -----
+    The optimal scaling factor is calculated by settings the derivative
+    of the cost function (:func:`cost_func`) with respect to the scaling
+    factor :math:`t_0` to zero and resolving for :math:`t_0`.
+
+    .. math::
+
+        -2 \sum_i
+        \left(
+            \frac{MSD_i MSD_i^{ref}}{t_i^2} -
+            t_0 \frac{MSD_i^2}{t_i^2}
+        \right)
+        = 0
+
+    .. math::
+
+        t_0 = \frac{
+            \frac{MSD_i MSD_i^{ref}}{t_i^2}
+        }{
+            \frac{MSD_i^2}{t_i^2}
+        }
+
+    The index :math:`i` labels the measured data points.
+
+    See notes in my "sketch book" from 22.01.2021.
+    """
+    times = np.asarray(times)
+    msd = np.asarray(msd)
+    msd_ref = np.asarray(msd_ref)
+
+    numerator = np.sum(msd * msd_ref / times**2)
+    denominator = np.sum(msd**2 / times**2)
+    return numerator / denominator
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the mean displacement and the displacement variance as function"
+        " of the diffusion time for various bins for a single simulation."
+    )
+)
+parser.add_argument(
+    "--system",
+    type=str,
+    required=True,
+    help="Name of the simulated system, e.g. lintf2_g1_20-1_gra_q1_sc80.",
+)
+parser.add_argument(
+    "--settings",
+    type=str,
+    required=False,
+    default="pr_nvt423_nh",
+    help=(
+        "String describing the used simulation settings.  Default:"
+        " %(default)s."
+    ),
+)
+parser.add_argument(
+    "--msd-component",
+    type=str,
+    required=False,
+    default="xy",
+    choices=("xy", "z"),
+    help="The MSD component to use for the analysis.  Default: %(default)s",
+)
+args = parser.parse_args()
+
+cmp = "Li"
+analysis = "msd_layer"  # Analysis name.
+analysis_suffix = "_" + cmp  # Analysis name specification.
+ana_path = os.path.join(analysis, analysis + analysis_suffix)
+tool = "mdt"  # Analysis software.
+outfile = (
+    args.settings
+    + "_"
+    + args.system
+    + "_"
+    + cmp
+    + "_displvar"
+    + args.msd_component
+    + "_layer_tscaled.pdf"
+)
+
+
+print("Creating Simulation instance(s)...")
+if "_gra_" in args.system:
+    surfq = leap.simulation.get_surfq(args.system)
+    top_path = "q%g" % surfq
+else:
+    surfq = None
+    top_path = "bulk"
+set_pat = "[0-9][0-9]_" + args.settings + "_" + args.system
+Sim = leap.simulation.get_sim(args.system, set_pat, top_path)
+
+
+print("Reading data...")
+if args.msd_component == "xy":
+    dimensions = ("x", "y")
+elif args.msd_component == "z":
+    dimensions = ("z",)
+else:
+    raise ValueError(
+        "Unknown --msd-component: '{}'".format(args.msd_component)
+    )
+md = [None for dim in dimensions]
+msd = [None for dim in dimensions]
+for dim_ix, dim in enumerate(dimensions):
+    (
+        times_dim,
+        bins_dim,
+        md_data,
+        msd_data,
+    ) = leap.simulation.read_displvar_single(Sim, cmp, dim)
+    stop = int(0.99 * len(times_dim))
+    if dim_ix == 0:
+        # Discard fist lag time of zero, because plots use log scale.
+        # Discard last one percent of the data, because they are quite
+        # noisy.
+        times, bins = times_dim[1:stop], bins_dim
+        md, msd = md_data[1:stop], msd_data[1:stop]
+    else:
+        if bins_dim.shape != bins.shape:
+            raise ValueError(
+                "The input files do not contain the same number of bins"
+            )
+        if not np.allclose(bins_dim, bins, atol=0):
+            raise ValueError(
+                "The bin edges are not the same in all input files"
+            )
+        times_dim = times_dim[1:stop]
+        if times_dim.shape != times.shape:
+            raise ValueError(
+                "The input files do not contain the same number of lag times"
+            )
+        if not np.allclose(times_dim, times, atol=0):
+            raise ValueError(
+                "The lag times are not the same in all input files"
+            )
+        md += md_data[1:stop]
+        msd += msd_data[1:stop]
+del times_dim, bins_dim, md_data, msd_data
+
+# Get displacements in the first layer at the right (negative) electrode
+# and in the bulk.
+valid_bins = np.isfinite(msd)
+valid_bins &= msd > 0
+valid_bins = np.any(valid_bins, axis=0)
+if np.count_nonzero(valid_bins) == 0:
+    raise ValueError(
+        "The displacement variances in all bins are NaN, inf or less than zero"
+    )
+last_bin = np.flatnonzero(valid_bins)[-1]
+bulk_bin = msd.shape[1] // 2 - 1
+md_wall, md_bulk = md[:, last_bin], md[:, bulk_bin]
+msd_wall, msd_bulk = msd[:, last_bin], msd[:, bulk_bin]
+del md, msd
+
+
+print("Calculating scaling factor...")
+# Scale the lag times of the displacement variance in the first layer at
+# the right (negative) electrode such that it has the greatest possible
+# overlap with the displacement variance in the bulk layer.
+# # Only use the first part of the MSD to determine the scaling factor,
+# # because the scaling factor is heavily influenced by the noise in the
+# # later part of the MSD.
+# _, scale_stop = mdt.nph.find_nearest(times, 1e2, return_index=True)
+scale_stop = len(times)
+tscales = np.zeros(2, dtype=np.float64)
+tscales[1] = opt_scaling(
+    times=times[:scale_stop],
+    msd=msd_wall[:scale_stop],
+    msd_ref=msd_bulk[:scale_stop],
+)
+tscales[0] = opt_scaling(
+    times=times[:scale_stop],
+    msd=msd_bulk[:scale_stop],
+    msd_ref=msd_bulk[:scale_stop],
+)
+
+
+print("Fitting straight line...")
+fit_start, fit_stop = int(np.sqrt(len(times))), len(times)
+popt, perr = fit_msd_slope1(times, msd_bulk, start=fit_start, stop=fit_stop)
+
+if np.isclose(Sim.Li_O_ratio, 1 / 20, rtol=0) and Sim.O_per_chain >= 16:
+    _, fit_start_region1 = mdt.nph.find_nearest(times, 2e-3, return_index=True)
+    _, fit_stop_region1 = mdt.nph.find_nearest(times, 2e-2, return_index=True)
+    popt_region1, perr_region1 = fit_msd(
+        times, msd_bulk, start=fit_start_region1, stop=fit_stop_region1
+    )
+    _, fit_start_region2 = mdt.nph.find_nearest(times, 1e-1, return_index=True)
+    _, fit_stop_region2 = mdt.nph.find_nearest(times, 1e1, return_index=True)
+    popt_region2, perr_region2 = fit_msd(
+        times, msd_bulk, start=fit_start_region2, stop=fit_stop_region2
+    )
+
+
+print("Creating plot(s)...")
+xlabel = r"Scaled Diffusion Time $\Delta t/t^{*}$"
+xlim = (times[0] / 4, times[-1])
+
+if cmp in ("NBT", "OBT", "OE"):
+    legend_title = "$" + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp] + "$" + ", "
+else:
+    legend_title = leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp] + ", "
+if surfq is not None:
+    legend_title += r"$\sigma_s = \pm %.2f$ $e$/nm$^2$" % surfq + "\n"
+legend_title += (
+    r"$n_{EO} = %d$, " % Sim.O_per_chain + r"$r = %.4f$" % Sim.Li_O_ratio
+)
+
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot mean displacement vs scaled time.
+    ylabel = r"$\langle \Delta "
+    if args.msd_component == "xy":
+        ylabel += r"\mathbf{r}_{%s}" % args.msd_component
+    elif args.msd_component == "z":
+        ylabel += r"%s" % args.msd_component
+    else:
+        raise ValueError(
+            "Unknown --msd-component: '{}'".format(args.msd_component)
+        )
+    ylabel += r" (\Delta t) \rangle$ / nm"
+    fig, ax = plt.subplots(clear=True)
+    ax.axhline(y=0, color="black")
+    md_min, md_max = 0, 0
+    for ix, (bin_ix, md) in enumerate(
+        zip((bulk_bin, last_bin), (md_bulk, md_wall))
+    ):
+        ax.plot(
+            times / tscales[ix],
+            md,
+            label=(
+                r"Bin $%d$, " % (bin_ix + 1)
+                + r"$t^{*} = %.2f$ ns" % tscales[ix]
+            ),
+            alpha=leap.plot.ALPHA,
+        )
+        md_min = min(md_min, np.nanmin(md))
+        md_max = max(md_max, np.nanmax(md))
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+    if md_max >= abs(md_min):
+        legend_loc = "upper left"
+    else:
+        legend_loc = "lower left"
+    legend = ax.legend(
+        title=legend_title, loc=legend_loc, **mdtplt.LEGEND_KWARGS_XSMALL
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot displacement variance vs scaled time.
+    ylabel = r"Var$[\Delta "
+    if args.msd_component == "xy":
+        ylabel += r"\mathbf{r}_{%s}" % args.msd_component
+    elif args.msd_component == "z":
+        ylabel += r"%s" % args.msd_component
+    else:
+        raise ValueError(
+            "Unknown --msd-component: '{}'".format(args.msd_component)
+        )
+    ylabel += r" (\Delta t)]$ / nm$^2$"
+    fig, ax = plt.subplots(clear=True)
+    for ix, (bin_ix, msd) in enumerate(
+        zip((bulk_bin, last_bin), (msd_bulk, msd_wall))
+    ):
+        ax.plot(
+            times / tscales[ix],
+            msd,
+            label=(
+                r"Bin $%d$, " % (bin_ix + 1)
+                + r"$t^{*} = %.2f$ ns" % tscales[ix]
+            ),
+            alpha=leap.plot.ALPHA,
+        )
+    ax.plot(
+        times[fit_start:fit_stop],
+        leap.misc.power_law(times[fit_start:fit_stop], m=1, c=popt[0]),
+        label=r"$\propto \Delta t^{1.00}$",
+        color="black",
+        linestyle="dashed",
+    )
+    if np.isclose(Sim.Li_O_ratio, 1 / 20, rtol=0) and Sim.O_per_chain >= 16:
+        fit = leap.misc.power_law(
+            times[fit_start_region1:fit_stop_region1], *popt_region1
+        )
+        ax.plot(
+            times[fit_start_region1:fit_stop_region1],
+            fit * 1.5,
+            label=r"$\propto \Delta t^{%.2f}$" % popt_region1[0],
+            linestyle="dashdot",
+        )
+        fit = leap.misc.power_law(
+            times[fit_start_region2:fit_stop_region2], *popt_region2
+        )
+        ax.plot(
+            times[fit_start_region2:fit_stop_region2],
+            fit * 1.5,
+            label=r"$\propto \Delta t^{%.2f}$" % popt_region2[0],
+            linestyle="dashdot",
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+    legend = ax.legend(
+        title=legend_title, loc="upper left", **mdtplt.LEGEND_KWARGS_XSMALL
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvarxy_layer_tscaled_vs_time.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvarxy_layer_tscaled_vs_time.py
@@ -365,14 +365,15 @@ with PdfPages(outfile) as pdf:
     # Plot mean displacement vs scaled time.
     ylabel = r"$\langle \Delta "
     if args.msd_component == "xy":
-        ylabel += r"\mathbf{r}_{%s}" % args.msd_component
+        ylabel += r"%s \rangle" % args.msd_component[0]
+        ylabel += r"+ \langle \Delta %s" % args.msd_component[1]
     elif args.msd_component == "z":
         ylabel += r"%s" % args.msd_component
     else:
         raise ValueError(
             "Unknown --msd-component: '{}'".format(args.msd_component)
         )
-    ylabel += r" (\Delta t) \rangle$ / nm"
+    ylabel += r" \rangle$ / nm"
     fig, ax = plt.subplots(clear=True)
     ax.axhline(y=0, color="black")
     md_min, md_max = 0, 0
@@ -413,7 +414,7 @@ with PdfPages(outfile) as pdf:
         raise ValueError(
             "Unknown --msd-component: '{}'".format(args.msd_component)
         )
-    ylabel += r" (\Delta t)]$ / nm$^2$"
+    ylabel += r"]$ / nm$^2$"
     fig, ax = plt.subplots(clear=True)
     for ix, (bin_ix, msd) in enumerate(
         zip((bulk_bin, last_bin), (msd_bulk, msd_wall))

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvarxy_layer_tscaled_vs_time.sh
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvarxy_layer_tscaled_vs_time.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+settings="pr_nvt423_nh"
+top_path="${HOME}/ownCloud/WWU_Münster/Promotion/Simulationen/results/lintf2_peo/walls"
+cmp="Li"
+msd_component="xy"
+
+########################################################################
+# Information and Usage Functions                                      #
+########################################################################
+
+information() {
+    echo "Loop over all surface-simulation directories and run the"
+    echo "Python script plot_displvarxy_layer_tscaled_vs_time.py to"
+    echo "scale and plot the displacement variance of the lithium ions"
+    echo "in the first layer at the right (negative) electrode such"
+    echo "that it overlaps with the corresponding displacement variance"
+    echo "in a bulk layer."
+}
+
+usage() {
+    echo
+    echo "Usage:"
+    echo
+    echo "Optional arguments:"
+    echo "  -h    Show this help message and exit."
+    echo "  -e    String describing the used simulation settings."
+    echo "        Default: '${settings}'."
+    echo "  -t    Top-level simulation path containing all surface"
+    echo "        simulations.  Default: '${top_path}'."
+}
+
+########################################################################
+# Argument Parsing                                                     #
+########################################################################
+
+while getopts he:t: option; do
+    case ${option} in
+        # Optional arguments.
+        h)
+            information
+            usage
+            exit 0
+            ;;
+        e)
+            settings=${OPTARG}
+            ;;
+        t)
+            top_path=${OPTARG}
+            ;;
+        # Handling of invalid options or missing arguments.
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -d ${top_path} ]]; then
+    echo "ERROR: No such directory: '${top_path}'"
+    exit 1
+fi
+
+########################################################################
+# Main Part                                                            #
+########################################################################
+
+cwd=$(pwd) # Current working directory.
+
+script_dir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+project_root=$(readlink -e "${script_dir}/../../../.." || exit)
+py_exe=".venv/bin/python3"
+py_exe="${project_root}/${py_exe}"
+py_script=$(readlink -e "${script_dir}/plot_displvarxy_layer_tscaled_vs_time.py" || exit)
+if [[ ! -d ${script_dir} ]]; then
+    echo "ERROR: No such directory '${script_dir}'"
+    exit 1
+fi
+if [[ ! -d ${project_root} ]]; then
+    echo "ERROR: No such directory '${project_root}'"
+    exit 1
+fi
+if [[ ! -x ${py_exe} ]]; then
+    echo "ERROR: No such executable '${py_exe}'"
+    exit 1
+fi
+if [[ ! -f ${py_script} ]]; then
+    echo "ERROR: No such file '${py_script}'"
+    exit 1
+fi
+
+analysis="msd_layer"
+tool="mdt"
+
+cd "${top_path}" || exit
+for surfq in q[0-9]*; do
+    echo
+    echo "============================================================="
+    echo "${surfq}"
+    if [[ ! -d ${surfq} ]]; then
+        echo "WARNING: No such directory: '${surfq}'"
+        continue
+    fi
+    cd "${surfq}" || exit
+
+    for system in lintf2_[gp]*[0-9]*_[0-9]*-[0-9]*_gra_"${surfq}"_sc80; do
+        echo
+        echo "${system}"
+        if [[ ! -d ${system} ]]; then
+            echo "WARNING: No such directory: '${system}'"
+            continue
+        fi
+        cd "${system}" || exit
+
+        sim_dir="${settings}_${system}"
+        if [[ ${system} != *_gra_* ]]; then
+            sim_dir="07_${sim_dir}"
+        elif [[ ${system} == *_gra_q0_* ]]; then
+            sim_dir="09_${sim_dir}"
+        else
+            sim_dir="01_${sim_dir}"
+        fi
+        if [[ ! -d ${sim_dir} ]]; then
+            echo "WARNING: No such directory: '${sim_dir}'"
+            cd ../ || exit
+            continue
+        fi
+        cd "${sim_dir}" || exit
+
+        ana_dir="ana_${settings}_${system}/${tool}/${analysis}"
+        if [[ ! -d ${ana_dir} ]]; then
+            echo "WARNING: No such directory: '${ana_dir}'"
+            cd ../../ || exit
+            continue
+        fi
+        cd "${ana_dir}" || exit
+
+        ana_sub_dir="${analysis}_${cmp}"
+        if [[ ! -d ${ana_sub_dir} ]]; then
+            echo "WARNING: No such directory: '${ana_sub_dir}'"
+            cd ../../../../../ || exit
+            continue
+        fi
+        cd "${ana_sub_dir}" || exit
+
+        ${py_exe} "${py_script}" \
+            --system "${system}" \
+            --settings "${settings}" \
+            --msd-component "${msd_component}" ||
+            exit
+
+        cd ../../../../../../ || exit
+    done
+
+    cd ../ || exit
+    echo "============================================================="
+done
+cd "${cwd}" || exit
+
+echo
+echo "Done"


### PR DESCRIPTION
# Create Scripts to Plot MSDs that Dependent on the Initial Particle Position (msd_layer)

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

* New Function `lintf2_ether_ana_postproc.simulation.read_displvar_single` that reads the displacement variance per bin from file for a single simulation.
* New Python script `scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.py` that plots the mean displacement and the displacement variance as function of the diffusion time for various bins for a single simulation.
* New Bash script `scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.sh` that loops over all surface-simulation directories and runs the Python script `plot_displvar_layer_vs_time.py` to plot the mean displacement and the displacement variance as function of the diffusion time for various bins.
* New Python script `scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.py` that plots the x-, y- and z-component of the mean displacement and the displacement variance as function of the initial particle position at a constant diffusion time for a single simulation.
* New Bash script `scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.sh` that loops over all surface-simulation directories and runs the Python script `plot_displvar_cross_section_xyz_at_const_time.py` to plot the x-, y- and z-component of the mean displacement and the displacement variance as function of the initial particle position at a constant diffusion time.
* New Python script `scripts/bulk_and_walls/mdt/msd_layer/plot_displvarxy_layer_tscaled_vs_time.py` that scales and plots the displacement variance of the lithium ions in the first layer at the right (negative) electrode such that it overlaps with the corresponding displacement variance in a bulk layer for a single simulation.
* New Bash script `scripts/bulk_and_walls/mdt/msd_layer/plot_displvarxy_layer_tscaled_vs_time.sh` that loops over all surface-simulation directories and runs the Python script `plot_displvarxy_layer_tscaled_vs_time.py` to scale and plot the displacement variance of the lithium ions in the first layer at the right (negative) electrode such that it overlaps with the corresponding displacement variance in a bulk layer.
* New Python script `scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_chain-length_dependence.py` that plots a given component of the mean displacement and the displacement variance in each bin at a constant diffusion time as function of the PEO chain length.
* New Python script `scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_conc_dependence.py` that plots a given component of the mean displacement and the displacement variance in each bin at a constant diffusion time as function of the salt concentration.
* New Python script `scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_surfq_dependence.py` that plots a given component of the mean displacement and the displacement variance in each bin at a constant diffusion time as function of the electrode surface charge.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] The CI workflow is passing.
