### PR TITLE
Common y Axis Limits for the Number of Valid Transitions in `plot_lig_change_at_pos_change_blocks_*.py`

### DIFF
--- a/scripts/bulk_and_walls/mdt/lig_change_at_pos_change_blocks/plot_lig_change_at_pos_change_blocks_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lig_change_at_pos_change_blocks/plot_lig_change_at_pos_change_blocks_chain-length_dependence.py
@@ -500,7 +500,7 @@ with PdfPages(outfile) as pdf:
             ylims = [(0, 6.4)] * 3
         else:
             ylims = [(0, 2.9)] * 3
-        ylims += [(1, None), (0, 1), (0, 100)]
+        ylims += [(1, 5e3), (0, 1), (0, 100)]
     else:
         ylims = [(None, None) for ylabel in ylabels]
     labels = ("To, Succ.", "To, Unsc.", "From, Succ.", "From, Unsc.")

--- a/scripts/bulk_and_walls/mdt/lig_change_at_pos_change_blocks/plot_lig_change_at_pos_change_blocks_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lig_change_at_pos_change_blocks/plot_lig_change_at_pos_change_blocks_conc_dependence.py
@@ -523,7 +523,7 @@ with PdfPages(outfile) as pdf:
             ylims = [(0, 6.4)] * 3
         else:
             ylims = [(0, 2.9)] * 3
-        ylims += [(1, None), (0, 1), (0, 100)]
+        ylims += [(1, 5e3), (0, 1), (0, 100)]
     else:
         ylims = [(None, None) for ylabel in ylabels]
     labels = ("To, Succ.", "To, Unsc.", "From, Succ.", "From, Unsc.")

--- a/scripts/bulk_and_walls/mdt/lig_change_at_pos_change_blocks/plot_lig_change_at_pos_change_blocks_surfq_dependence.py
+++ b/scripts/bulk_and_walls/mdt/lig_change_at_pos_change_blocks/plot_lig_change_at_pos_change_blocks_surfq_dependence.py
@@ -488,7 +488,7 @@ with PdfPages(outfile) as pdf:
             ylims = [(0, 6.4)] * 3
         else:
             ylims = [(0, 2.9)] * 3
-        ylims += [(1, None), (0, 1), (0, 100)]
+        ylims += [(1, 5e3), (0, 1), (0, 100)]
     else:
         ylims = [(None, None) for ylabel in ylabels]
     labels = ("To, Succ.", "To, Unsc.", "From, Succ.", "From, Unsc.")


### PR DESCRIPTION
# Common y Axis Limits for the Number of Valid Transitions in `plot_lig_change_at_pos_change_blocks_*.py`

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [ ] New feature.
* [x] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

Python scripts `plot_lig_change_at_pos_change_blocks_chain-length_dependence.py`, `plot_lig_change_at_pos_change_blocks_conc_dependence.py` and `plot_lig_change_at_pos_change_blocks_surfq_dependence.py`: Set a common upper limit for the y axis of the plot of the number of valid barrier transitions.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [ ] New/changed code is properly documented.
* [ ] The CI workflow is passing.
