### PR TITLE
`plot_hex_bin_lifetimes_conc_dependence.py`: Add Plots

### DIFF
--- a/scripts/bulk_and_walls/mdt/discrete-hex/plot_hex_bin_lifetimes_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/discrete-hex/plot_hex_bin_lifetimes_conc_dependence.py
@@ -93,7 +93,7 @@ analysis = "discrete-hex"  # Analysis name.
 analysis_suffix = "_" + args.cmp
 outfile = (
     settings
-    + "_lintf2_peoN_r_gra_"
+    + "_lintf2_g1_g4_peo63_r_gra_"
     + args.surfq
     + "_sc80_"
     + analysis
@@ -101,6 +101,42 @@ outfile = (
     + args.cmp
     + "_lifetimes_count_censored.pdf"
 )
+
+# Columns to read from the input files.
+col_rt_sd = 2
+cols = (
+    0,  # Li-to-EO ratio.
+    1,  # Residence time (count censored) [ns].
+    col_rt_sd,  # Std of residence time [ns].
+    3,  # Corrected sample standard deviation [ns].
+    4,  # Corrected coefficient of variation.
+    5,  # Unbiased sample skewness (Fisher).
+    6,  # Unbiased sample excess kurtosis (Fisher).
+    7,  # Sample median [ns].
+    8,  # Non-parametric skewness.
+    12,  # Sample minimum [ns].
+    13,  # Sample maximum [ns].
+    14,  # Number of samples.
+)
+ylabels = (
+    "Residence Time / ps",
+    "Std. Dev. / ps",
+    "Coeff. of Variation",
+    "Skewness",
+    "Excess Kurtosis",
+    "Median / ps",
+    "Non-Parametric Skewness",
+    "Min. Residence Time / ps",
+    "Max. Residence Time / ps",
+    "No. of Samples",
+)
+if len(ylabels) != len(cols) - 2:
+    raise ValueError(
+        "`len(ylabels)` ({}) != `len(cols)` - 2"
+        " ({})".format(len(ylabels), len(cols) - 2)
+    )
+ylabels_has_unit = np.array([False for ylb in ylabels])
+ylabels_has_unit[[0, 1, 5, 7, 8]] = True
 
 
 print("Reading data...")
@@ -120,16 +156,18 @@ for sol_ix, sol in enumerate(sols):
         + args.cmp
         + "_lifetimes_continuous.txt.gz"
     )
-    xdata[sol_ix], ydata[sol_ix], ydata_sd[sol_ix] = np.loadtxt(
-        infile, usecols=(0, 1, 2), unpack=True
-    )
-    ydata[sol_ix] *= 1e3  # ns -> ps.
+    data = np.loadtxt(infile, usecols=cols, unpack=True)
+    xdata[sol_ix] = data[0]
+    ydata[sol_ix] = data[1:]
+    ydata[sol_ix] = np.delete(ydata[sol_ix], cols.index(col_rt_sd) - 1, axis=0)
+    ydata_sd[sol_ix] = data[cols.index(col_rt_sd)]
+    ydata[sol_ix][ylabels_has_unit] *= 1e3  # ns -> ps.
     ydata_sd[sol_ix] *= 1e3  # Std[c*A] = |c| * Std[A]
+del data
 
 
 print("Creating plot(s)...")
 xlabel = r"Li-to-EO Ratio $r$"
-ylabel = "Residence Time / ps"
 xlim = (0, 0.4 + 0.0125)
 ylim = (None, None)
 
@@ -138,7 +176,6 @@ legend_title = (
     + "\n"
     + r"$n_{EO}$"
 )
-n_legend_cols = 3
 
 labels = (r"$2$", r"$5$", r"$64$")
 markers = ("o", "s", "^")
@@ -151,31 +188,64 @@ colors = cmap(c_vals_normed)
 
 mdt.fh.backup(outfile)
 with PdfPages(outfile) as pdf:
-    fig, ax = plt.subplots(clear=True)
-    ax.set_prop_cycle(color=colors)
-    for sol_ix, _sol in enumerate(sols):
-        ax.errorbar(
-            xdata[sol_ix],
-            ydata[sol_ix],
-            yerr=ydata_sd[sol_ix],
-            label=labels[sol_ix],
-            marker=markers[sol_ix],
+    for ylb_ix, ylabel in enumerate(ylabels):
+        fig, ax = plt.subplots(clear=True)
+        ax.set_prop_cycle(color=colors)
+
+        if ylabel == "Coeff. of Variation":
+            y_exp = 1  # Coeff. of variation of exp. distribution.
+        elif ylabel == "Skewness":
+            y_exp = 2  # Skewness of exponential distribution.
+        elif ylabel == "Excess Kurtosis":
+            y_exp = 6  # Excess kurtosis of exponential distribution.
+        elif ylabel == "Non-Parametric Skewness":
+            y_exp = 1 - np.log(2)  # Non-param. skew. of exp. dist.
+        else:
+            y_exp = None
+            n_legend_cols = 3
+        if y_exp is not None:
+            ax.axhline(
+                y=y_exp,
+                color="tab:green",
+                linestyle="dashed",
+                label="Exp. Dist.",
+            )
+            n_legend_cols = 2
+
+        for sol_ix, _sol in enumerate(sols):
+            if ylb_ix == cols.index(col_rt_sd) - 2:
+                ax.errorbar(
+                    xdata[sol_ix],
+                    ydata[sol_ix][ylb_ix],
+                    yerr=ydata_sd[sol_ix],
+                    label=labels[sol_ix],
+                    marker=markers[sol_ix],
+                )
+            else:
+                ax.plot(
+                    xdata[sol_ix],
+                    ydata[sol_ix][ylb_ix],
+                    label=labels[sol_ix],
+                    marker=markers[sol_ix],
+                )
+        ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
+        equalize_xticks(ax)
+        equalize_yticks(ax)
+        legend = ax.legend(
+            title=legend_title,
+            ncol=n_legend_cols,
+            **mdtplt.LEGEND_KWARGS_XSMALL,
         )
-    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
-    equalize_xticks(ax)
-    equalize_yticks(ax)
-    legend = ax.legend(
-        title=legend_title, ncol=n_legend_cols, **mdtplt.LEGEND_KWARGS_XSMALL
-    )
-    legend.get_title().set_multialignment("center")
-    pdf.savefig(fig)
-    # Log scale y.
-    ax.relim()
-    ax.autoscale()
-    ax.set_yscale("log", base=10, subs=np.arange(2, 10))
-    ax.set(xlim=xlim, ylim=(4e0, 1e1))
-    pdf.savefig(fig)
-    plt.close(fig)
+        legend.get_title().set_multialignment("center")
+        pdf.savefig(fig)
+
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(xlim=xlim, ylim=ylim)
+        pdf.savefig(fig)
+        plt.close(fig)
 
 print("Created {}".format(outfile))
 print("Done")


### PR DESCRIPTION
# `plot_hex_bin_lifetimes_conc_dependence.py`: Add Plots

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

`plot_hex_bin_lifetimes_conc_dependence.py`: Additionally to the mean residence times, also plot characteristics of the residence time distribution (like skewness, kurtosis, etc.).

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [ ] New/changed code is properly documented.
* [ ] The CI workflow is passing.
