### PR TITLE
Refactor Scripts That Plot Position-Resolved Displacement Variances

### DIFF
--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_chain-length_dependence.py
@@ -61,7 +61,7 @@ def legend_title(surfq_sign):
     else:
         legend_title = leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + ", "
     legend_title += (
-        r"$\Delta t = %.1f$ ns" % args.time
+        r"$\Delta t = %.2f$ ns" % args.time
         + "\n"
         + r"$\sigma_s = "
         + surfq_sign

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_conc_dependence.py
@@ -61,7 +61,7 @@ def legend_title(surfq_sign):
     else:
         legend_title = leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + ", "
     legend_title += (
-        r"$\Delta t = %.1f$ ns" % args.time
+        r"$\Delta t = %.2f$ ns" % args.time
         + "\n"
         + r"$\sigma_s = "
         + surfq_sign

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_surfq_dependence.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_at_const_time_surfq_dependence.py
@@ -413,7 +413,7 @@ if args.cmp in ("NBT", "OBT", "OE"):
 else:
     legend_title = leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + ", "
 legend_title += (
-    r"$\Delta t = %.1f$ ns" % args.time
+    r"$\Delta t = %.2f$ ns" % args.time
     + "\n"
     + r"$n_{EO} = %d$, " % Sims.O_per_chain[0]
     + r"$r = %.2f$" % Sims.Li_O_ratios[0]

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.py
@@ -148,7 +148,7 @@ if args.cmp in ("NBT", "OBT", "OE"):
     )
 else:
     legend_title = leap.plot.ATOM_TYPE2DISPLAY_NAME[args.cmp] + ", "
-legend_title += r"$\Delta t = %.1f$ ns" % time + "\n"
+legend_title += r"$\Delta t = %.2f$ ns" % time + "\n"
 if surfq is not None:
     legend_title += r"$\sigma_s = \pm %.2f$ $e$/nm$^2$" % surfq + "\n"
 legend_title += (

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
 """
-Plot the x-, y- and z-component of the mean displacement and the
-displacement variance as function of the initial particle position at a
-constant diffusion time for a single simulation.
+Plot the x-, y- and z-component of the mean displacement, the mean
+squared displacement and the displacement variance as function of the
+initial particle position at a constant diffusion time for a single
+simulation.
 """
 
 
@@ -101,13 +102,19 @@ args.time /= 1e3  # ps -> ns.
 dimensions = ("x", "y", "z")
 md_at_const_time = [None for dim in dimensions]
 msd_at_const_time = [None for dim in dimensions]
+# True MSD, not displacement variance
+msd_at_const_time_true = [None for dim in dimensions]
 for dim_ix, dim in enumerate(dimensions):
     (
         times_dim,
         bins_dim,
         md_data,
-        msd_data,
-    ) = leap.simulation.read_displvar_single(Sim, args.cmp, dim)
+        msd_data_true,
+    ) = leap.simulation.read_displvar_single(
+        Sim, args.cmp, dim, displvar=False
+    )
+    # Calculate displacement variance.
+    msd_data = msd_data_true - md_data**2
     if dim_ix == 0:
         times, bins = times_dim, bins_dim
     else:
@@ -130,8 +137,9 @@ for dim_ix, dim in enumerate(dimensions):
     time, tix = mdt.nph.find_nearest(times, args.time, return_index=True)
     md_at_const_time[dim_ix] = md_data[tix]
     msd_at_const_time[dim_ix] = msd_data[tix]
+    msd_at_const_time_true[dim_ix] = msd_data_true[tix]
 bin_mids = bins[1:] - np.diff(bins) / 2
-del times, times_dim, bins_dim, md_data, msd_data
+del times, times_dim, bins_dim, md_data, msd_data, msd_data_true
 
 
 print("Creating plot(s)...")
@@ -203,6 +211,42 @@ with PdfPages(outfile) as pdf:
     legend = ax.legend(
         title=legend_title,
         loc=legend_loc,
+        ncol=n_legend_cols,
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot true MSD vs initial position.
+    ylabel = r"$\langle \Delta\mathbf{r}^2 \rangle$ / nm$^2$"
+    fig, axs = plt.subplots(
+        clear=True,
+        nrows=2,
+        sharex=True,
+        gridspec_kw={"height_ratios": height_ratios},
+    )
+    fig.set_figheight(fig.get_figheight() * sum(height_ratios))
+    ax_profile, ax = axs
+    leap.plot.profile(ax_profile, Sim=Sim, free_en=True)
+    if surfq is not None:
+        leap.plot.elctrds(
+            ax, offset_left=elctrd_thk, offset_right=box_z - elctrd_thk
+        )
+    for dim_ix, dim in enumerate(dimensions):
+        ax.plot(
+            bin_mids,
+            msd_at_const_time_true[dim_ix],
+            label="$" + dim + "$",
+            marker=markers[dim_ix],
+        )
+    leap.plot.bins(ax, bins=bins)
+    ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+    ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+    legend = ax.legend(
+        title=legend_title,
+        loc="lower center",
         ncol=n_legend_cols,
         **mdtplt.LEGEND_KWARGS_XSMALL,
     )

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.sh
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_cross_section_xyz_at_const_time.sh
@@ -12,9 +12,10 @@ flags=()
 information() {
     echo "Loop over all surface-simulation directories and run the"
     echo "Python script plot_displvar_cross_section_xyz_at_const_time.py"
-    echo "to plot the x-, y- and z-component of the mean displacement"
-    echo "and the displacement variance as function of the initial"
-    echo "particle position at a constant diffusion time."
+    echo "to plot the x-, y- and z-component of the mean displacement,"
+    echo "the mean squared displacement and the displacement variance"
+    echo "as function of the initial particle position at a constant"
+    echo "diffusion time."
 }
 
 usage() {

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.py
@@ -135,12 +135,13 @@ times, bins, md_data, msd_data = leap.simulation.read_displvar_single(
 times = times[1:]
 md_data = md_data[1:]
 msd_data = msd_data[1:]
+msd_0_min = np.nanmin(msd_data[0])
 
 
 print("Fitting straight line...")
 bin_nums = np.arange(1, len(bins))
 bin_ix = len(bin_nums) // 2 - 1
-fit_start, fit_stop = int(np.sqrt(len(times))), int(0.99 * len(times))
+fit_start, fit_stop = int(np.sqrt(len(times))), int(0.98 * len(times))
 popt, perr = fit_msd_slope1(
     times, msd_data[:, bin_ix], start=fit_start, stop=fit_stop
 )
@@ -222,11 +223,9 @@ with PdfPages(outfile) as pdf:
     for bix, bin_num in enumerate(bin_nums):
         if np.all(np.isnan(msd_data[:, bix])):
             continue
-        # Discard last data points, because they are quite noisy and
-        # tend to distort the automatic y axis scaling.
         ax.plot(
-            times[:fit_stop],
-            msd_data[:, bix][:fit_stop],
+            times,
+            msd_data[:, bix],
             label=r"$%d$" % bin_num,
             alpha=leap.plot.ALPHA,
             rasterized=True,
@@ -241,6 +240,9 @@ with PdfPages(outfile) as pdf:
     ax.set_xscale("log", base=10, subs=np.arange(2, 10))
     ax.set_yscale("log", base=10, subs=np.arange(2, 10))
     ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim)
+    ylim = ax.get_ylim()
+    if ylim[0] < msd_0_min / 2:
+        ax.set_ylim(msd_0_min / 2, ylim[1])
     legend = ax.legend(
         title=legend_title,
         loc="upper left",

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.py
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.py
@@ -208,7 +208,7 @@ with PdfPages(outfile) as pdf:
     legend = ax.legend(
         title=legend_title,
         loc=legend_loc,
-        ncol=1 + len(bin_nums) // 4,
+        ncol=1 + n_bins_valid // 4,
         **mdtplt.LEGEND_KWARGS_XSMALL,
     )
     legend.get_title().set_multialignment("center")
@@ -244,7 +244,7 @@ with PdfPages(outfile) as pdf:
     legend = ax.legend(
         title=legend_title,
         loc="upper left",
-        ncol=1 + len(bin_nums) // 6,
+        ncol=1 + n_bins_valid // 5,
         **mdtplt.LEGEND_KWARGS_XSMALL,
     )
     legend.get_title().set_multialignment("center")

--- a/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.sh
+++ b/scripts/bulk_and_walls/mdt/msd_layer/plot_displvar_layer_vs_time.sh
@@ -11,8 +11,9 @@ cmp=Li
 information() {
     echo "Loop over all surface-simulation directories and run the"
     echo "Python script plot_displvar_layer_vs_time.py to plot the mean"
-    echo "displacement and the displacement variance as function of the"
-    echo "diffusion time for various bins."
+    echo "displacement, the mean squared displacement and the"
+    echo "displacement variance as function of the diffusion time for"
+    echo "various bins."
 }
 
 usage() {


### PR DESCRIPTION
# Refactor Scripts That Plot Position-Resolved Displacement Variances

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [x] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

* Python scripts `scripts/bulk-and-walls/mdt/msd-layer/plot_displvar_cross_section_*.py`: Print the diffusion time in the legend using two instead of one decimal places.
* Python script `scripts/bulk-and-walls/mdt/msd-layer/plot_displvar_layer_vs_time.py`:
  * Correct number of legend columns.
  * Improve automatic y axis scale.
  * Include plot of the true MSD.
* Python script `scripts/bulk-and-walls/mdt/msd-layer/plot_displvar_cross_section_xyz_at_const_time.py`: Include plot of the true MSD.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [ ] New/changed code is properly documented.
* [ ] The CI workflow is passing.
