### PR TITLE
Fix Comment in `plot_density_chain-length_dependence.py`

### DIFF
--- a/scripts/bulk_and_walls/gmx/energy/plot_density_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/gmx/energy/plot_density_chain-length_dependence.py
@@ -99,7 +99,7 @@ Becht_1967_353K_ydata = np.asarray([Becht_1967_353K, 1 / Becht_1967_353K])
 # Zhang et al., J. Phys. Chem. B, 2014, 118, 19, 5144–5153.
 # Values taken from Table S1 in SI.
 # r = Li/EO ~ 1/20 = 0.05
-# Actual r values:  0.0625,  0.0417,  0.0625,  0.0500
+# Actual r values:  0.0625,  0.0556,  0.0625,  0.0500
 # 1/r = EO/Li:     16.00  , 18.00  , 16.00  , 20.00
 n_eo = np.asarray([2, 3, 4, 5])
 Zhang_2014_303K = np.asarray([1.0510, 1.1049, 1.1610, 1.1550])


### PR DESCRIPTION
# Fix Comment in `plot_density_chain-length_dependence.py`

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [x] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

`scripts/bulk_and_walls/gmx/energy/plot_density_chain-length_dependence.py`: Fix wrong r value (Li/EO ratio) in a comment.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [~] New/changed code is properly tested.
* [~] New/changed code is properly documented.
* [ ] The CI workflow is passing.
