### PR TITLE
Fix Type Casting Bug in Scripts that plot the Renewal Events per Lithium Ion in each Layer

### DIFF
--- a/scripts/bulk_and_walls/mdt/renewal_events_walls/plot_renewal_event_num_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events_walls/plot_renewal_event_num_chain-length_dependence.py
@@ -303,7 +303,7 @@ ydata = [
     [[[] for sim in Sims.sims] for pkp_type in pk_pos_types]
     for dat_ix in range(n_data)
 ]
-n_events_per_refcmp_bulk = np.zeros(Sims.n_sims, dtype=np.uint32)
+n_events_per_refcmp_bulk = np.zeros(Sims.n_sims, dtype=np.float64)
 for sim_ix, Sim in enumerate(Sims.sims):
     # Get file that contains the renewal event information for the
     # corresponding bulk simulation.

--- a/scripts/bulk_and_walls/mdt/renewal_events_walls/plot_renewal_event_num_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events_walls/plot_renewal_event_num_conc_dependence.py
@@ -325,7 +325,7 @@ ydata = [
     [[[] for sim in Sims.sims] for pkp_type in pk_pos_types]
     for dat_ix in range(n_data)
 ]
-n_events_per_refcmp_bulk = np.zeros(Sims.n_sims, dtype=np.uint32)
+n_events_per_refcmp_bulk = np.zeros(Sims.n_sims, dtype=np.float64)
 for sim_ix, Sim in enumerate(Sims.sims):
     # Get file that contains the renewal event information for the
     # corresponding bulk simulation.

--- a/scripts/bulk_and_walls/mdt/renewal_events_walls/plot_renewal_event_num_surfq_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events_walls/plot_renewal_event_num_surfq_dependence.py
@@ -272,7 +272,7 @@ ydata = [
     [[[] for sim in Sims.sims] for pkp_type in pk_pos_types]
     for dat_ix in range(n_data)
 ]
-n_events_per_refcmp_bulk = np.zeros(Sims.n_sims, dtype=np.uint32)
+n_events_per_refcmp_bulk = np.zeros(Sims.n_sims, dtype=np.float64)
 for sim_ix, Sim in enumerate(Sims.sims):
     # Get file that contains the renewal event information for the
     # corresponding bulk simulation.


### PR DESCRIPTION
# Fix Type Casting Bug in Scripts that plot the Renewal Events per Lithium Ion in each Layer

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [x] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

`scripts/bulk_and_walls/mdt/renewal_events_walls/plot_renewal_event_num_*.py`: Fix a type casting bug in the calculation of the number of renewal events per reference compound in the bulk simulations.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [ ] New/changed code is properly documented.
* [ ] The CI workflow is passing.
