### PR TITLE
Fix Scripts to Plot Transition Rates Computed From Free-Energy Barriers

### DIFF
--- a/scripts/bulk_and_walls/gmx/density-z/plot_free-energy_trans_rate_chain-length_dependence_cluster.py
+++ b/scripts/bulk_and_walls/gmx/density-z/plot_free-energy_trans_rate_chain-length_dependence_cluster.py
@@ -283,7 +283,7 @@ for pkt_ix, _minima_pkp_pkt in enumerate(minima[pkp_col_ix]):
         rates_l2r = np.exp(-beta * bars_l2r_sim)
         rates_r2l = np.exp(-beta * bars_r2l_sim)
         rates_mean = np.exp(-beta * bars_l2r_sim[1:])
-        rates_mean += np.exp(-bars_r2l_sim[:-1])
+        rates_mean += np.exp(-beta * bars_r2l_sim[:-1])
         rates_mean /= 2
         rates_mean = np.insert(rates_mean, 0, np.exp(-beta * bars_l2r_sim[0]))
 

--- a/scripts/bulk_and_walls/gmx/density-z/plot_free-energy_trans_rate_conc_dependence_cluster.py
+++ b/scripts/bulk_and_walls/gmx/density-z/plot_free-energy_trans_rate_conc_dependence_cluster.py
@@ -306,7 +306,7 @@ for pkt_ix, _minima_pkp_pkt in enumerate(minima[pkp_col_ix]):
         rates_l2r = np.exp(-beta * bars_l2r_sim)
         rates_r2l = np.exp(-beta * bars_r2l_sim)
         rates_mean = np.exp(-beta * bars_l2r_sim[1:])
-        rates_mean += np.exp(-bars_r2l_sim[:-1])
+        rates_mean += np.exp(-beta * bars_r2l_sim[:-1])
         rates_mean /= 2
         rates_mean = np.insert(rates_mean, 0, np.exp(-beta * bars_l2r_sim[0]))
 

--- a/scripts/bulk_and_walls/gmx/density-z/plot_free-energy_trans_rate_surfq_dependence_cluster.py
+++ b/scripts/bulk_and_walls/gmx/density-z/plot_free-energy_trans_rate_surfq_dependence_cluster.py
@@ -290,7 +290,7 @@ for pkt_ix, _minima_pkp_pkt in enumerate(minima[pkp_col_ix]):
         rates_l2r = np.exp(-beta * bars_l2r_sim)
         rates_r2l = np.exp(-beta * bars_r2l_sim)
         rates_mean = np.exp(-beta * bars_l2r_sim[1:])
-        rates_mean += np.exp(-bars_r2l_sim[:-1])
+        rates_mean += np.exp(-beta * bars_r2l_sim[:-1])
         rates_mean /= 2
         rates_mean = np.insert(rates_mean, 0, np.exp(-beta * bars_l2r_sim[0]))
 


### PR DESCRIPTION
# Fix Scripts to Plot Transition Rates Computed From Free-Energy Barriers

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [x] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

Add missing beta in the expression for the Boltzmann weight for calculating the transition rates from the barrier heights, i.e. exp(-beta * barrier). This has no effect on created plots, because beta is equal to one, because the barrier heights are already given in units of kT.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [~] New/changed code is properly documented.
* [ ] The CI workflow is passing.
