### PR TITLE
Scripts to plot block averaged coordination numbers and correlation times

### DIFF
--- a/scripts/bulk_and_walls/mdt/contact_hist/plot_contact_hist_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/contact_hist/plot_contact_hist_chain-length_dependence.py
@@ -91,15 +91,15 @@ elif args.cmp == "Li-O":
     ylim_denticity = ylim_cn
 else:
     raise ValueError("Invalid --cmp: {}".format(args.cmp))
-if len(col_labels) != len(cols):
+if len(col_labels) != n_cols:
     raise ValueError(
-        "`len(col_labels)` ({}) != `len(cols)`"
-        " ({})".format(len(col_labels), len(cols))
+        "`len(col_labels)` ({}) != `n_cols`"
+        " ({})".format(len(col_labels), n_cols)
     )
-if len(xlim_hist) != len(cols):
+if len(xlim_hist) != n_cols:
     raise ValueError(
-        "`len(xlim_hist)` ({}) != `len(cols)`"
-        " ({})".format(len(xlim_hist), len(cols))
+        "`len(xlim_hist)` ({}) != `n_cols`"
+        " ({})".format(len(xlim_hist), n_cols)
     )
 
 # Maximum number of contacts to consider when plotting the fraction of
@@ -140,7 +140,7 @@ Sims = leap.simulation.get_sims(
 
 
 print("Reading data and creating plot(s)...")
-file_suffix = analysis + "_" + args.cmp + ".txt.gz"
+file_suffix = analysis + analysis_suffix + ".txt.gz"
 infiles = leap.simulation.get_ana_files(Sims, analysis, tool, file_suffix)
 n_infiles = len(infiles)
 

--- a/scripts/bulk_and_walls/mdt/contact_hist/plot_contact_hist_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/contact_hist/plot_contact_hist_conc_dependence.py
@@ -120,15 +120,15 @@ elif args.cmp == "Li-O":
     ylim_denticity = ylim_cn
 else:
     raise ValueError("Invalid --cmp: {}".format(args.cmp))
-if len(col_labels) != len(cols):
+if len(col_labels) != n_cols:
     raise ValueError(
-        "`len(col_labels)` ({}) != `len(cols)`"
-        " ({})".format(len(col_labels), len(cols))
+        "`len(col_labels)` ({}) != `n_cols`"
+        " ({})".format(len(col_labels), n_cols)
     )
-if len(xlim_hist) != len(cols):
+if len(xlim_hist) != n_cols:
     raise ValueError(
-        "`len(xlim_hist)` ({}) != `len(cols)`"
-        " ({})".format(len(xlim_hist), len(cols))
+        "`len(xlim_hist)` ({}) != `n_cols`"
+        " ({})".format(len(xlim_hist), n_cols)
     )
 
 # Maximum number of contacts to consider when plotting the fraction of
@@ -169,7 +169,7 @@ Sims = leap.simulation.get_sims(
 
 
 print("Reading data and creating plot(s)...")
-file_suffix = analysis + "_" + args.cmp + ".txt.gz"
+file_suffix = analysis + analysis_suffix + ".txt.gz"
 infiles = leap.simulation.get_ana_files(Sims, analysis, tool, file_suffix)
 n_infiles = len(infiles)
 

--- a/scripts/bulk_and_walls/mdt/contact_hist_block_average/plot_contact_hist_block_av_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/contact_hist_block_average/plot_contact_hist_block_av_chain-length_dependence.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the contact histograms and average coordination numbers for two
+given compounds as function of the PEO chain length.  Estimate the
+standard error of the mean values from block averages.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import FormatStrFormatter, MaxNLocator
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def equalize_yticks(ax):
+    """
+    Equalize y-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the y
+        ticks.
+    """
+    ylim = np.asarray(ax.get_ylim())
+    ylim_diff = ylim[-1] - ylim[0]
+    yticks = np.asarray(ax.get_yticks())
+    yticks_valid = (yticks >= ylim[0]) & (yticks <= ylim[-1])
+    yticks = yticks[yticks_valid]
+    if ylim_diff >= 10 and ylim_diff < 20:
+        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+    if np.all(yticks >= 0) and np.all(yticks < 10) and ylim_diff > 2:
+        ax.yaxis.set_major_formatter(FormatStrFormatter("%.1f"))
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the contact histograms and average coordination numbers for two"
+        " given compounds as function of the PEO chain length.  Estimate the"
+        " standard error of the mean values from block averages."
+    )
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=True,
+    choices=("Li-OE", "Li-OBT", "Li-O"),
+    help="Compounds for which to plot the coordination numbers.",
+)
+args = parser.parse_args()
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+analysis = "contact_hist"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+analysis_dir = analysis + "_block_average"
+ana_path = os.path.join(analysis_dir, analysis + analysis_suffix)
+tool = "mdt"  # Analysis software.
+outfile = (  # Output file name.
+    settings
+    + "_lintf2_peoN_20-1_sc80_"
+    + analysis_dir
+    + analysis_suffix
+    + ".pdf"
+)
+
+# Blocks used for block averaging
+blocks = list(range(0, 1100, 100))
+n_blocks = len(blocks) - 1
+
+cols = (  # Columns to read from the input file(s).
+    # 0,  # Number of contacts N.
+    1,  # Ratio of Li ions that have contact with N different O atoms.
+    2,  # Ratio of Li ions that have contact with N different PEO/TFSI molecules.  # noqa: E501
+    5,  # Ratio of Li-PEO/TFSI complexes with N-dentate coordination.
+)
+n_cols = len(cols)
+if args.cmp == "Li-OE":
+    col_labels = (r"$Li - O_{PEO}$", r"$Li - PEO$", r"$Li - PEO$")
+    xlim_hist = [(0, 8), (0, 6), (0, 8)]
+    ylim_cn = (0, 6.5)
+    ylim_denticity = ylim_cn
+elif args.cmp == "Li-OBT":
+    col_labels = (r"$Li - O_{TFSI}$", r"$Li - TFSI$", r"$Li - TFSI$")
+    xlim_hist = [(0, 8), (0, 6), (0, 8)]
+    ylim_cn = (0, 0.42)
+    ylim_denticity = (0.9, 1.3)
+elif args.cmp == "Li-O":
+    col_labels = (r"$Li - O_{tot}$", r"$Li - PEO/TFSI$", r"$Li - PEO/TFSI$")
+    xlim_hist = [(0, 8), (0, 6), (0, 8)]
+    ylim_cn = (0, 6.5)
+    ylim_denticity = ylim_cn
+else:
+    raise ValueError("Invalid --cmp: {}".format(args.cmp))
+if len(col_labels) != n_cols:
+    raise ValueError(
+        "`len(col_labels)` ({}) != `n_cols`"
+        " ({})".format(len(col_labels), n_cols)
+    )
+if len(xlim_hist) != n_cols:
+    raise ValueError(
+        "`len(xlim_hist)` ({}) != `n_cols`"
+        " ({})".format(len(xlim_hist), n_cols)
+    )
+
+# Maximum number of contacts to consider when plotting the fraction of
+# lithium ions that have contact to N different O atoms or N different
+# PEO/TFSI molecules as function of the chain length.
+if args.cmp == "Li-OE":
+    n_cnt_max = (
+        7,  # Maximum number of different O atoms.
+        3,  # Maximum number of different PEO molecules.
+        7,  # Maximum denticity of a Li-PEO complex.
+    )
+elif args.cmp == "Li-OBT":
+    n_cnt_max = (
+        2,  # Maximum number of different O atoms.
+        2,  # Maximum number of different TFSI molecules.
+        2,  # Maximum denticity of a Li-TFSI complex.
+    )
+elif args.cmp == "Li-O":
+    n_cnt_max = (
+        7,  # Maximum number of different O atoms.
+        4,  # Maximum number of different molecules.
+        7,  # Maximum denticity of a Li-PEO or Li-TFSI complex.
+    )
+else:
+    raise ValueError("Unknown --cmp {}".format(args.cmp))
+if len(n_cnt_max) != n_cols:
+    raise ValueError(
+        "`len(n_cnt_max)` ({}) != `n_cols` ({})".format(len(n_cnt_max), n_cols)
+    )
+
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_[gp]*[0-9]*_20-1_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, path_key="bulk", sort_key="O_per_chain"
+)
+
+
+print("Calculating coordination numbers...")
+# Average coordination number of a lithium ion.
+cn = np.zeros((n_blocks, n_cols, Sims.n_sims), dtype=np.float64)
+# Probability that a lithium ion has N contacts.
+prob_n_cnt = np.zeros(
+    (n_blocks, n_cols, max(n_cnt_max) + 2, Sims.n_sims), dtype=np.float64
+)
+
+for sim_ix, Sim in enumerate(Sims.sims):
+    for block_ix, block_start in enumerate(blocks[:-1]):
+        block_end = blocks[block_ix + 1]
+        file_suffix = (
+            analysis
+            + analysis_suffix
+            + "_"
+            + str(block_start)
+            + "-"
+            + str(block_end)
+            + "ns.txt.gz"
+        )
+        infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+        # Read input file.
+        data = np.loadtxt(infile, usecols=(0,) + cols)
+        # Skip last row that contains the sum of each column.
+        data = data[:-1]
+        # Number of contacts.
+        n_contacts = data.T[0]
+        n_contacts = np.round(n_contacts, out=n_contacts).astype(np.uint16)
+        # Probability that a lithium ion has N contacts.
+        probabilities = data.T[1:]
+        for col_ix in range(n_cols):
+            # Calculate average coordination numbers.
+            cn[block_ix][col_ix][sim_ix] = np.sum(
+                n_contacts * probabilities[col_ix]
+            )
+            # Probability that a lithium ion has N contacts.
+            for n_cnt, prob in zip(n_contacts, probabilities[col_ix]):
+                if n_cnt >= len(prob_n_cnt[block_ix][col_ix]):
+                    break
+                prob_n_cnt[block_ix][col_ix][n_cnt][sim_ix] = prob
+
+
+print("Calculating block averages...")
+cn_av, cn_se = mdt.statistics.block_average(cn, axis=0, ddof=1)
+prob_n_cnt_av, prob_n_cnt_se = mdt.statistics.block_average(
+    prob_n_cnt, axis=0, ddof=1
+)
+del cn, prob_n_cnt
+if not np.allclose(np.sum(prob_n_cnt_av, axis=1), 1, atol=5e-3):
+    print(np.sum(prob_n_cnt_av, axis=1))
+    raise ValueError("The sum of all coordination probabilities is not unity")
+
+
+print("Creating plot(s)...")
+xlim = (1, 200)
+ylim_prob = (0, 1)
+xlabel = r"Ether Oxygens per Chain $n_{EO}$"
+legend_title = r"$r = %.2f$" % Sims.Li_O_ratios[0]
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot coordination number histograms.
+    xlabels = ("Coordination Number", "Coordination Number", "Denticity")
+    cmap = plt.get_cmap()
+    c_vals = np.arange(Sims.n_sims)
+    c_norm = max(Sims.n_sims - 1, 1)
+    c_vals_normed = c_vals / c_norm
+    colors = cmap(c_vals_normed)
+    for col_ix, probabilities in enumerate(prob_n_cnt_av):
+        fig, ax = plt.subplots(clear=True)
+        ax.set_prop_cycle(color=colors)
+        for sim_ix, Sim in enumerate(Sims.sims):
+            if Sim.O_per_chain == 2:
+                color = "tab:red"
+                ax.plot([], [])  # Increment color cycle.
+            elif Sim.O_per_chain == 3:
+                color = "tab:brown"
+                ax.plot([], [])  # Increment color cycle.
+            elif Sim.O_per_chain == 5:
+                color = "tab:orange"
+                ax.plot([], [])  # Increment color cycle.
+            else:
+                color = None
+            # ax.plot(
+            #     np.arange(
+            #         probabilities[:, sim_ix].size, dtype=np.uint8
+            #     ),
+            #     probabilities[:, sim_ix],
+            #     label=r"$%d$" % Sim.O_per_chain,
+            #     color=color,
+            #     alpha=leap.plot.ALPHA,
+            # )
+            ax.errorbar(
+                np.arange(probabilities[:, sim_ix].size, dtype=np.uint8),
+                probabilities[:, sim_ix],
+                yerr=prob_n_cnt_se[col_ix, :, sim_ix],
+                label=r"$%d$" % Sim.O_per_chain,
+                color=color,
+                alpha=leap.plot.ALPHA,
+            )
+        ax.set(
+            xlabel=xlabels[col_ix],
+            ylabel="Probability",
+            xlim=xlim_hist[col_ix],
+            ylim=ylim_prob,
+        )
+        ax.xaxis.set_tick_params(which="minor", bottom=False, top=False)
+        ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+        legend = ax.legend(
+            title=(
+                col_labels[col_ix] + "\n" + legend_title + "\n" + r"$n_{EO}$"
+            ),
+            ncol=1 + Sims.n_sims // (6 + 1),
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+    # Plot the probability that a lithium ion has N contacts as function
+    # of the chain length.
+    legend_title_suffixes = (" Coord. No.", " Coord. No.", " Denticity")
+    markers = ("o", "|", "x", "^", "s", "p", "h", "*", "8", "v")
+    if len(markers) < max(n_cnt_max):
+        raise ValueError(
+            "`len(markers)` ({}) < `max(n_cnt_max)`"
+            " ({})".format(len(markers), max(n_cnt_max))
+        )
+    for col_ix, probabilities in enumerate(prob_n_cnt_av):
+        cmap = plt.get_cmap()
+        c_vals = np.arange(n_cnt_max[col_ix] + 1)
+        c_norm = max(n_cnt_max[col_ix], 1)
+        c_vals_normed = c_vals / c_norm
+        colors = cmap(c_vals_normed)
+        fig, ax = plt.subplots(clear=True)
+        ax.set_prop_cycle(color=colors)
+        for n_cnt, prob in enumerate(probabilities):
+            if n_cnt > n_cnt_max[col_ix]:
+                break
+            # ax.plot(
+            #     Sims.O_per_chain,
+            #     prob,
+            #     label=r"$%d$" % n_cnt,
+            #     marker=markers[n_cnt],
+            #     alpha=leap.plot.ALPHA,
+            # )
+            ax.errorbar(
+                Sims.O_per_chain,
+                prob,
+                yerr=prob_n_cnt_se[col_ix, n_cnt],
+                label=r"$%d$" % n_cnt,
+                marker=markers[n_cnt],
+                alpha=leap.plot.ALPHA,
+            )
+        ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(xlabel=xlabel, ylabel="Probability", xlim=xlim, ylim=ylim_prob)
+        if args.cmp == "Li-OE" and col_ix in (0, 2):
+            legend_loc = "best"
+            n_legend_cols = 4
+        elif args.cmp == "Li-O" and col_ix in (0, 2):
+            legend_loc = "center right"
+            n_legend_cols = 4
+        else:
+            legend_loc = "best"
+            n_legend_cols = 3
+        legend = ax.legend(
+            loc=legend_loc,
+            title=(
+                legend_title
+                + "\n"
+                + col_labels[col_ix]
+                + legend_title_suffixes[col_ix]
+            ),
+            ncol=n_legend_cols,
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+    # Plot average coordination numbers.
+    markers = ("^", "v")
+    fig, ax = plt.subplots(clear=True)
+    for col_ix in [cols.index(1), cols.index(2)]:
+        ax.errorbar(
+            Sims.O_per_chain,
+            cn_av[col_ix],
+            yerr=cn_se[col_ix],
+            label=col_labels[col_ix],
+            marker=markers[col_ix],
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel=xlabel, ylabel="Coordination Number", xlim=xlim, ylim=ylim_cn
+    )
+    equalize_yticks(ax)
+    ax.legend(title=legend_title)
+    pdf.savefig()
+    plt.close()
+
+    # Plot average denticities.
+    fig, ax = plt.subplots(clear=True)
+    for col_ix in [cols.index(5)]:
+        ax.errorbar(
+            Sims.O_per_chain,
+            cn_av[col_ix],
+            yerr=cn_se[col_ix],
+            label=col_labels[col_ix],
+            marker="o",
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(
+        xlabel=xlabel,
+        ylabel="Average Denticity",
+        xlim=xlim,
+        ylim=ylim_denticity,
+    )
+    equalize_yticks(ax)
+    ax.legend(title=legend_title)
+    pdf.savefig()
+    plt.close()
+
+    # Plot the standard error of the probability that a lithium ion has
+    # N contacts as function of the chain length.
+    legend_title_suffixes = (" Coord. No.", " Coord. No.", " Denticity")
+    markers = ("o", "|", "x", "^", "s", "p", "h", "*", "8", "v")
+    if len(markers) < max(n_cnt_max):
+        raise ValueError(
+            "`len(markers)` ({}) < `max(n_cnt_max)`"
+            " ({})".format(len(markers), max(n_cnt_max))
+        )
+    for col_ix, prob_errors in enumerate(prob_n_cnt_se):
+        cmap = plt.get_cmap()
+        c_vals = np.arange(n_cnt_max[col_ix] + 1)
+        c_norm = max(n_cnt_max[col_ix], 1)
+        c_vals_normed = c_vals / c_norm
+        colors = cmap(c_vals_normed)
+        fig, ax = plt.subplots(clear=True)
+        ax.set_prop_cycle(color=colors)
+        for n_cnt, prob_error in enumerate(prob_errors):
+            if n_cnt > n_cnt_max[col_ix]:
+                break
+            ax.plot(
+                Sims.O_per_chain,
+                prob_error,
+                label=r"$%d$" % n_cnt,
+                marker=markers[n_cnt],
+                alpha=leap.plot.ALPHA,
+            )
+        ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(xlabel=xlabel, ylabel="Std. Err. of Prob.", xlim=xlim)
+        legend = ax.legend(
+            loc="best",
+            title=(
+                legend_title
+                + "\n"
+                + col_labels[col_ix]
+                + legend_title_suffixes[col_ix]
+            ),
+            ncol=n_legend_cols,
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+    # Plot the standard error of the average coordination numbers.
+    markers = ("^", "v")
+    fig, ax = plt.subplots(clear=True)
+    for col_ix in [cols.index(1), cols.index(2)]:
+        ax.plot(
+            Sims.O_per_chain,
+            cn_se[col_ix],
+            label=col_labels[col_ix],
+            marker=markers[col_ix],
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel="Std. Err. of CN", xlim=xlim)
+    equalize_yticks(ax)
+    ax.legend(title=legend_title)
+    pdf.savefig()
+    plt.close()
+
+    # Plot the standard error of the average denticities.
+    fig, ax = plt.subplots(clear=True)
+    for col_ix in [cols.index(5)]:
+        ax.plot(
+            Sims.O_per_chain,
+            cn_se[col_ix],
+            label=col_labels[col_ix],
+            marker="o",
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel="Std. Err. of Denticity", xlim=xlim)
+    equalize_yticks(ax)
+    ax.legend(title=legend_title)
+    pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/contact_hist_block_average/plot_contact_hist_block_av_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/contact_hist_block_average/plot_contact_hist_block_av_conc_dependence.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the contact histograms and average coordination numbers for two
+given compounds as function of the salt concentration.  Estimate the
+standard error of the mean values from block averages.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import FormatStrFormatter, MaxNLocator, MultipleLocator
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def equalize_xticks(ax):
+    """
+    Equalize x-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the x
+        ticks.
+    """
+    ax.xaxis.set_major_locator(MultipleLocator(0.1))
+
+
+def equalize_yticks(ax):
+    """
+    Equalize y-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the y
+        ticks.
+    """
+    ylim = np.asarray(ax.get_ylim())
+    ylim_diff = ylim[-1] - ylim[0]
+    yticks = np.asarray(ax.get_yticks())
+    yticks_valid = (yticks >= ylim[0]) & (yticks <= ylim[-1])
+    yticks = yticks[yticks_valid]
+    if ylim_diff >= 10 and ylim_diff < 20:
+        ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+    if np.all(yticks >= 0) and np.all(yticks < 10) and ylim_diff > 2:
+        ax.yaxis.set_major_formatter(FormatStrFormatter("%.1f"))
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the contact histograms and average coordination numbers for two"
+        " given compounds as function of the salt concentration.  Estimate the"
+        " standard error of the mean values from block averages."
+    )
+)
+parser.add_argument(
+    "--sol",
+    type=str,
+    required=True,
+    choices=("g1", "g4", "peo63"),
+    help="Solvent name.",
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=True,
+    choices=("Li-OE", "Li-OBT", "Li-O"),
+    help=(
+        "Compounds for which to plot the coordination numbers.  Default:"
+        " %(default)s"
+    ),
+)
+args = parser.parse_args()
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+analysis = "contact_hist"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+analysis_dir = analysis + "_block_average"
+ana_path = os.path.join(analysis_dir, analysis + analysis_suffix)
+tool = "mdt"  # Analysis software.
+outfile = (  # Output file name.
+    settings
+    + "_lintf2_"
+    + args.sol
+    + "_r_sc80_"
+    + analysis_dir
+    + analysis_suffix
+    + ".pdf"
+)
+
+# Blocks used for block averaging
+blocks = list(range(0, 1100, 100))
+n_blocks = len(blocks) - 1
+
+cols = (  # Columns to read from the input file(s).
+    # 0,  # Number of contacts N.
+    1,  # Ratio of Li ions that have contact with N different O atoms.
+    2,  # Ratio of Li ions that have contact with N different PEO/TFSI molecules.  # noqa: E501
+    5,  # Ratio of Li-PEO/TFSI complexes with N-dentate coordination.
+)
+n_cols = len(cols)
+if args.cmp == "Li-OE":
+    col_labels = (r"$Li - O_{PEO}$", r"$Li - PEO$", r"$Li - PEO$")
+    xlim_hist = [(0, 8), (0, 6), (0, 8)]
+    ylim_cn = (0, 6.5)
+    ylim_denticity = ylim_cn
+elif args.cmp == "Li-OBT":
+    col_labels = (r"$Li - O_{TFSI}$", r"$Li - TFSI$", r"$Li - TFSI$")
+    xlim_hist = [(0, 8), (0, 6), (0, 8)]
+    ylim_cn = (0, 2.9)
+    ylim_denticity = (0.9, 1.3)
+elif args.cmp == "Li-O":
+    col_labels = (r"$Li - O_{tot}$", r"$Li - PEO/TFSI$", r"$Li - PEO/TFSI$")
+    xlim_hist = [(0, 8), (0, 6), (0, 8)]
+    ylim_cn = (0, 6.5)
+    ylim_denticity = ylim_cn
+else:
+    raise ValueError("Invalid --cmp: {}".format(args.cmp))
+if len(col_labels) != n_cols:
+    raise ValueError(
+        "`len(col_labels)` ({}) != `n_cols`"
+        " ({})".format(len(col_labels), n_cols)
+    )
+if len(xlim_hist) != n_cols:
+    raise ValueError(
+        "`len(xlim_hist)` ({}) != `n_cols`"
+        " ({})".format(len(xlim_hist), n_cols)
+    )
+
+# Maximum number of contacts to consider when plotting the fraction of
+# lithium ions that have contact to N different O atoms or N different
+# PEO/TFSI molecules as function of the salt concentration.
+if args.cmp == "Li-OE":
+    n_cnt_max = (
+        7,  # Maximum number of different O atoms.
+        3,  # Maximum number of different PEO molecules.
+        7,  # Maximum denticity of a Li-PEO complex.
+    )
+elif args.cmp == "Li-OBT":
+    n_cnt_max = (
+        6,  # Maximum number of different O atoms.
+        5,  # Maximum number of different TFSI molecules.
+        2,  # Maximum denticity of a Li-TFSI complex.
+    )
+elif args.cmp == "Li-O":
+    n_cnt_max = (
+        7,  # Maximum number of different O atoms.
+        5,  # Maximum number of different molecules.
+        7,  # Maximum denticity of a Li-PEO or Li-TFSI complex.
+    )
+else:
+    raise ValueError("Unknown --cmp {}".format(args.cmp))
+if len(n_cnt_max) != n_cols:
+    raise ValueError(
+        "`len(n_cnt_max)` ({}) != `n_cols` ({})".format(len(n_cnt_max), n_cols)
+    )
+
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_" + args.sol + "_[0-9]*-[0-9]*_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, path_key="bulk", sort_key="Li_O_ratio"
+)
+
+
+print("Calculating coordination numbers...")
+# Average coordination number of a lithium ion.
+cn = np.zeros((n_blocks, n_cols, Sims.n_sims), dtype=np.float64)
+# Probability that a lithium ion has N contacts.
+prob_n_cnt = np.zeros(
+    (n_blocks, n_cols, max(n_cnt_max) + 2, Sims.n_sims), dtype=np.float64
+)
+
+for sim_ix, Sim in enumerate(Sims.sims):
+    for block_ix, block_start in enumerate(blocks[:-1]):
+        block_end = blocks[block_ix + 1]
+        file_suffix = (
+            analysis
+            + analysis_suffix
+            + "_"
+            + str(block_start)
+            + "-"
+            + str(block_end)
+            + "ns.txt.gz"
+        )
+        infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+        # Read input file.
+        data = np.loadtxt(infile, usecols=(0,) + cols)
+        # Skip last row that contains the sum of each column.
+        data = data[:-1]
+        # Number of contacts.
+        n_contacts = data.T[0]
+        n_contacts = np.round(n_contacts, out=n_contacts).astype(np.uint16)
+        # Probability that a lithium ion has N contacts.
+        probabilities = data.T[1:]
+        for col_ix in range(n_cols):
+            # Calculate average coordination numbers.
+            cn[block_ix][col_ix][sim_ix] = np.sum(
+                n_contacts * probabilities[col_ix]
+            )
+            # Probability that a lithium ion has N contacts.
+            for n_cnt, prob in zip(n_contacts, probabilities[col_ix]):
+                if n_cnt >= len(prob_n_cnt[block_ix][col_ix]):
+                    break
+                prob_n_cnt[block_ix][col_ix][n_cnt][sim_ix] = prob
+
+
+print("Calculating block averages...")
+cn_av, cn_se = mdt.statistics.block_average(cn, axis=0, ddof=1)
+prob_n_cnt_av, prob_n_cnt_se = mdt.statistics.block_average(
+    prob_n_cnt, axis=0, ddof=1
+)
+del cn, prob_n_cnt
+if not np.allclose(np.sum(prob_n_cnt_av, axis=1), 1, atol=5e-3):
+    print(np.sum(prob_n_cnt_av, axis=1))
+    raise ValueError("The sum of all coordination probabilities is not unity")
+
+
+print("Creating plot(s)...")
+xlim = (0, 0.4 + 0.0125)
+ylim_prob = (0, 1)
+xlabel = r"Li-to-EO Ratio $r$"
+legend_title = r"$n_{EO} = %d$" % Sims.O_per_chain[0]
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot coordination number histograms.
+    xlabels = ("Coordination Number", "Coordination Number", "Denticity")
+    cmap = plt.get_cmap()
+    c_vals = np.arange(Sims.n_sims)
+    c_norm = max(Sims.n_sims - 1, 1)
+    c_vals_normed = c_vals / c_norm
+    colors = cmap(c_vals_normed)
+    for col_ix, probabilities in enumerate(prob_n_cnt_av):
+        fig, ax = plt.subplots(clear=True)
+        ax.set_prop_cycle(color=colors)
+        for sim_ix, Sim in enumerate(Sims.sims):
+            # ax.plot(
+            #     np.arange(
+            #         probabilities[:, sim_ix].size, dtype=np.uint8
+            #     ),
+            #     probabilities[:, sim_ix],
+            #     label="$%.4f$" % Sim.Li_O_ratio,
+            #     alpha=leap.plot.ALPHA,
+            # )
+            ax.errorbar(
+                np.arange(probabilities[:, sim_ix].size, dtype=np.uint8),
+                probabilities[:, sim_ix],
+                yerr=prob_n_cnt_se[col_ix, :, sim_ix],
+                label="$%.4f$" % Sim.Li_O_ratio,
+                alpha=leap.plot.ALPHA,
+            )
+        ax.set(
+            xlabel=xlabels[col_ix],
+            ylabel="Probability",
+            xlim=xlim_hist[col_ix],
+            ylim=ylim_prob,
+        )
+        ax.xaxis.set_tick_params(which="minor", bottom=False, top=False)
+        ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+        legend = ax.legend(
+            title=col_labels[col_ix] + ", " + legend_title + "\n" + r"$r$",
+            ncol=1 + Sims.n_sims // (6 + 1),
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+    # Plot the probability that a lithium ion has N contacts as function
+    # of the chain length.
+    legend_title_suffixes = (" Coord. No.", " Coord. No.", " Denticity")
+    markers = ("o", "|", "x", "^", "s", "p", "h", "*", "8", "v")
+    if len(markers) < max(n_cnt_max):
+        raise ValueError(
+            "`len(markers)` ({}) < `max(n_cnt_max)`"
+            " ({})".format(len(markers), max(n_cnt_max))
+        )
+    for col_ix, probabilities in enumerate(prob_n_cnt_av):
+        cmap = plt.get_cmap()
+        c_vals = np.arange(n_cnt_max[col_ix] + 1)
+        c_norm = max(n_cnt_max[col_ix], 1)
+        c_vals_normed = c_vals / c_norm
+        colors = cmap(c_vals_normed)
+        fig, ax = plt.subplots(clear=True)
+        ax.set_prop_cycle(color=colors)
+        for n_cnt, prob in enumerate(probabilities):
+            if n_cnt > n_cnt_max[col_ix]:
+                break
+            # ax.plot(
+            #     Sims.Li_O_ratios,
+            #     prob,
+            #     label=r"$%d$" % n_cnt,
+            #     marker=markers[n_cnt],
+            #     alpha=leap.plot.ALPHA,
+            # )
+            ax.errorbar(
+                Sims.Li_O_ratios,
+                prob,
+                yerr=prob_n_cnt_se[col_ix, n_cnt],
+                label=r"$%d$" % n_cnt,
+                marker=markers[n_cnt],
+                alpha=leap.plot.ALPHA,
+            )
+        ax.set(xlabel=xlabel, ylabel="Probability", xlim=xlim, ylim=ylim_prob)
+        equalize_xticks(ax)
+        legend = ax.legend(
+            title=(
+                legend_title
+                + "\n"
+                + col_labels[col_ix]
+                + legend_title_suffixes[col_ix]
+            ),
+            ncol=3,
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+    # Plot average coordination numbers.
+    markers = ("^", "v")
+    fig, ax = plt.subplots(clear=True)
+    for col_ix in [cols.index(1), cols.index(2)]:
+        ax.errorbar(
+            Sims.Li_O_ratios,
+            cn_av[col_ix],
+            yerr=cn_se[col_ix],
+            label=col_labels[col_ix],
+            marker=markers[col_ix],
+        )
+    ax.set(
+        xlabel=xlabel, ylabel="Coordination Number", xlim=xlim, ylim=ylim_cn
+    )
+    equalize_xticks(ax)
+    equalize_yticks(ax)
+    ax.legend(title=legend_title)
+    pdf.savefig()
+    plt.close()
+
+    # Plot average denticities.
+    fig, ax = plt.subplots(clear=True)
+    for col_ix in [cols.index(5)]:
+        ax.errorbar(
+            Sims.Li_O_ratios,
+            cn_av[col_ix],
+            yerr=cn_se[col_ix],
+            label=col_labels[col_ix],
+            marker="o",
+        )
+    ax.set(
+        xlabel=xlabel,
+        ylabel="Average Denticity",
+        xlim=xlim,
+        ylim=ylim_denticity,
+    )
+    equalize_xticks(ax)
+    equalize_yticks(ax)
+    ax.legend(title=legend_title)
+    pdf.savefig()
+    plt.close()
+
+    # Plot the standard error of the probability that a lithium ion has
+    # N contacts as function of the chain length.
+    legend_title_suffixes = (" Coord. No.", " Coord. No.", " Denticity")
+    markers = ("o", "|", "x", "^", "s", "p", "h", "*", "8", "v")
+    if len(markers) < max(n_cnt_max):
+        raise ValueError(
+            "`len(markers)` ({}) < `max(n_cnt_max)`"
+            " ({})".format(len(markers), max(n_cnt_max))
+        )
+    for col_ix, prob_errors in enumerate(prob_n_cnt_se):
+        cmap = plt.get_cmap()
+        c_vals = np.arange(n_cnt_max[col_ix] + 1)
+        c_norm = max(n_cnt_max[col_ix], 1)
+        c_vals_normed = c_vals / c_norm
+        colors = cmap(c_vals_normed)
+        fig, ax = plt.subplots(clear=True)
+        ax.set_prop_cycle(color=colors)
+        for n_cnt, prob_error in enumerate(prob_errors):
+            if n_cnt > n_cnt_max[col_ix]:
+                break
+            ax.plot(
+                Sims.Li_O_ratios,
+                prob_error,
+                label=r"$%d$" % n_cnt,
+                marker=markers[n_cnt],
+                alpha=leap.plot.ALPHA,
+            )
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set(xlabel=xlabel, ylabel="Std. Err. of Prob.", xlim=xlim)
+        equalize_xticks(ax)
+        legend = ax.legend(
+            title=(
+                legend_title
+                + "\n"
+                + col_labels[col_ix]
+                + legend_title_suffixes[col_ix]
+            ),
+            ncol=3,
+            **mdtplt.LEGEND_KWARGS_XSMALL,
+        )
+        legend.get_title().set_multialignment("center")
+        pdf.savefig()
+        plt.close()
+
+    # Plot the standard error of the average coordination numbers.
+    markers = ("^", "v")
+    fig, ax = plt.subplots(clear=True)
+    for col_ix in [cols.index(1), cols.index(2)]:
+        ax.plot(
+            Sims.Li_O_ratios,
+            cn_se[col_ix],
+            label=col_labels[col_ix],
+            marker=markers[col_ix],
+        )
+    ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel="Std. Err. of CN", xlim=xlim)
+    equalize_xticks(ax)
+    equalize_yticks(ax)
+    ax.legend(title=legend_title)
+    pdf.savefig()
+    plt.close()
+
+    # Plot the standard error of the average denticities.
+    fig, ax = plt.subplots(clear=True)
+    for col_ix in [cols.index(5)]:
+        ax.plot(
+            Sims.Li_O_ratios,
+            cn_se[col_ix],
+            label=col_labels[col_ix],
+            marker="o",
+        )
+    ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel="Std. Err. of Denticity", xlim=xlim)
+    equalize_xticks(ax)
+    equalize_yticks(ax)
+    ax.legend(title=legend_title)
+    pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/lifetime_autocorr_block_average/plot_lifetime_autocorr_block_av.py
+++ b/scripts/bulk_and_walls/mdt/lifetime_autocorr_block_average/plot_lifetime_autocorr_block_av.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the lifetime autocorrelation function for two given compounds as
+function of the trajectory blocks used for block averaging.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import MaxNLocator
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the lifetime autocorrelation function for two given compounds as"
+        " function of the trajectory blocks used for block averaging."
+    ),
+)
+parser.add_argument(
+    "--system",
+    type=str,
+    required=True,
+    help="Name of the simulated system, e.g. lintf2_g1_20-1_sc80.",
+)
+parser.add_argument(
+    "--settings",
+    type=str,
+    required=False,
+    default="pr_nvt423_nh",
+    help=(
+        "String describing the used simulation settings.  Default:"
+        " %(default)s."
+    ),
+)
+parser.add_argument(
+    "--cmp",
+    type=str,
+    required=True,
+    choices=("Li-OE", "Li-OBT", "Li-ether", "Li-NTf2"),
+    help="Compounds for which to plot the lifetime autocorrelation function.",
+)
+args = parser.parse_args()
+cmp1, cmp2 = args.cmp.split("-")
+
+analysis = "lifetime_autocorr"  # Analysis name.
+analysis_suffix = "_" + args.cmp  # Analysis name specification.
+analysis_dir = analysis + "_block_average"
+ana_path = os.path.join(analysis_dir, analysis + analysis_suffix)
+tool = "mdt"  # Analysis software.
+outfile_base = (  # Output file name.
+    args.settings + "_" + args.system + "_" + analysis_dir + analysis_suffix
+)
+outfile_txt = outfile_base + ".txt.gz"
+outfile_pdf = outfile_base + ".pdf"
+
+# Blocks used for block averaging
+blocks = list(range(0, 1200, 200))
+n_blocks = len(blocks) - 1
+
+cols = (  # Columns to read from the input file(s).
+    0,  # Lag times in [ps].
+    1,  # Autocorrelation function.
+)
+
+# Only calculate the lifetime by directly integrating the ACF if the ACF
+# decayed below the given threshold.
+int_thresh = 0.01
+
+
+print("Creating Simulation instance(s)...")
+set_pat = "[0-9][0-9]_" + args.settings + "_" + args.system
+Sim = leap.simulation.get_sim(args.system, set_pat, path_key="bulk")
+
+
+print("Reading data...")
+# Lifetime autocorrelation functions for each trajectory block.
+times = None
+acfs = [None for i in range(n_blocks)]
+lifetimes = np.full(n_blocks, np.nan, dtype=np.float64)
+for block_ix, block_start in enumerate(blocks[:-1]):
+    block_end = blocks[block_ix + 1]
+    file_suffix = (
+        analysis
+        + analysis_suffix
+        + "_"
+        + str(block_start)
+        + "-"
+        + str(block_end)
+        + "ns.txt.gz"
+    )
+    infile = leap.simulation.get_ana_file(Sim, ana_path, tool, file_suffix)
+    times_sim, acf = np.loadtxt(infile, usecols=cols, unpack=True)
+    times_sim *= 1e-3  # ps -> ns
+    acfs[block_ix] = acf
+    if times is None:
+        times = np.copy(times_sim)
+    elif times_sim.shape != times.shape:
+        raise ValueError(
+            "`times_sim.shape` ({}) != `times.shape` ({})".format(
+                times_sim.shape, times.shape
+            )
+        )
+    elif not np.allclose(times_sim, times, atol=1e-09, rtol=0):
+        raise ValueError(
+            "The times in `times_sim` differ from those in `times`"
+        )
+    if np.any(acf <= int_thresh):
+        # Only calculate the lifetime by numerical integration if the
+        # ACF decays below the given threshold.
+        # Only calculate the ACF until its global minimum, a potential
+        # increase of the ACF after the minimum is likely a finite size
+        # artifact and should therefore be discarded.
+        stop = np.nanargmin(acf) + 1
+        lifetimes[block_ix] = leap.lifetimes.raw_moment_integrate(
+            sf=acf[:stop], x=times_sim[:stop]
+        )
+del times_sim, acf
+
+# Lifetime autocorrelation function over the full trajectory.
+file_suffix = analysis + analysis_suffix + ".txt.gz"
+infile = leap.simulation.get_ana_file(Sim, analysis, tool, file_suffix)
+times_total, acf_total = np.loadtxt(infile, usecols=cols, unpack=True)
+times_total *= 1e-3  # ps -> ns
+if np.any(acf_total <= int_thresh):
+    # Only calculate the lifetime by numerical integration if the ACF
+    # decays below the given threshold.
+    # Only calculate the ACF until its global minimum, a potential
+    # increase of the ACF after the minimum is likely a finite size
+    # artifact and should therefore be discarded.
+    stop = np.nanargmin(acf_total) + 1
+    lifetime_total = leap.lifetimes.raw_moment_integrate(
+        sf=acf_total, x=times_total
+    )
+else:
+    lifetime_total = np.nan
+
+
+print("Calculating block averages...")
+acfs = np.asarray(acfs)
+acf_av, acf_se = mdt.statistics.block_average(acfs, axis=0, ddof=1)
+n_lifetime_measurements = np.count_nonzero(np.isfinite(lifetimes))
+if n_lifetime_measurements == 1:
+    lifetime_av = lifetimes[np.isfinite(lifetimes)][0]
+    lifetime_se = np.nan
+elif n_lifetime_measurements > 1:
+    lifetime_av = np.nanmean(lifetimes)
+    lifetime_se = np.nanstd(lifetimes, ddof=1) / np.sqrt(
+        n_lifetime_measurements
+    )
+else:
+    lifetime_av, lifetime_se = np.nan, np.nan
+
+# Calculate lifetime from average autocorrelation function.
+if np.any(acf_av <= int_thresh):
+    # Only calculate the lifetime by numerical integration if the ACF
+    # decays below the given threshold.
+    # Only calculate the ACF until its global minimum, a potential
+    # increase of the ACF after the minimum is likely a finite size
+    # artifact and should therefore be discarded.
+    stop = np.nanargmin(acf_av) + 1
+    lifetime_acf_av = leap.lifetimes.raw_moment_integrate(sf=acf_av, x=times)
+else:
+    lifetime_acf_av = np.nan
+
+
+print("Creating plot(s)...")
+xlabel = "Lag Time / ns"
+ylabel = "Autocorrelation Function"
+xlim = (2e-3, 1e3)
+ylim = (0, 1)
+
+legend_title_base = (
+    r"$"
+    + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp1]
+    + "-"
+    + leap.plot.ATOM_TYPE2DISPLAY_NAME[cmp2]
+    + r"$"
+    + "\n"
+    + r"$n_{EO} = %d$" % Sim.O_per_chain
+    + ", "
+    + r"$r = %.4f$" % Sim.Li_O_ratio
+)
+
+cmap = plt.get_cmap()
+c_vals = np.arange(n_blocks)
+c_norm = max(n_blocks - 1, 1)
+c_vals_normed = c_vals / c_norm
+colors = cmap(c_vals_normed)
+
+mdt.fh.backup(outfile_pdf)
+with PdfPages(outfile_pdf) as pdf:
+    # Plot autocorrelation functions.
+    fig, ax = plt.subplots(clear=True)
+    ax.set_prop_cycle(color=colors)
+    # Autocorrelation function for each trajectory block.
+    for block_ix, block_start in enumerate(blocks[:-1]):
+        block_end = blocks[block_ix + 1]
+        ax.plot(
+            times,
+            acfs[block_ix],
+            label="$" + str(block_start) + "-" + str(block_end) + "$ ns",
+            alpha=leap.plot.ALPHA,
+        )
+    # Average autocorrelation function.
+    ax.plot(
+        times,
+        acf_av,
+        label="Average",
+        color="red",
+        linestyle="dashed",
+        alpha=leap.plot.ALPHA,
+    )
+    # ax.fill_between(
+    #     times,
+    #     y1=acf_av + acf_se,
+    #     y2=acf_av - acf_se,
+    #     color="red",
+    #     edgecolor=None,
+    #     alpha=leap.plot.ALPHA / 2,
+    #     rasterized=True,
+    # )
+    # Autocorrelation function for full trajectory.
+    ax.plot(
+        times_total,
+        acf_total,
+        label="Full trajectory",
+        color="orange",
+        linestyle="dotted",
+        alpha=leap.plot.ALPHA,
+    )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel=ylabel, xlim=xlim, ylim=ylim)
+    legend = ax.legend(
+        title=legend_title_base,
+        loc="best",
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot lifetimes as function of block.
+    xlim = np.asarray([0.5, n_blocks + 0.5])
+    fig, ax = plt.subplots(clear=True)
+    ax.plot(np.arange(1, n_blocks + 1), lifetimes, color=colors[0], marker="o")
+    if np.isfinite(lifetime_av):
+        ax.axhline(
+            lifetime_av,
+            label="Mean",
+            color=colors[1],
+            linestyle="dashed",
+            alpha=leap.plot.ALPHA,
+        )
+        ax.fill_between(
+            xlim,
+            y1=np.full(xlim.shape, lifetime_av + lifetime_se),
+            y2=np.full(xlim.shape, lifetime_av - lifetime_se),
+            color=colors[1],
+            edgecolor=None,
+            alpha=leap.plot.ALPHA / 2,
+        )
+    if np.isfinite(lifetime_acf_av):
+        ax.axhline(
+            lifetime_acf_av,
+            label="Average ACF",
+            color="red",
+            linestyle="dashed",
+            alpha=leap.plot.ALPHA,
+        )
+    if np.isfinite(lifetime_total):
+        ax.axhline(
+            lifetime_total,
+            label="Full ACF",
+            color="orange",
+            linestyle="dotted",
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set(
+        xlabel="Trajectory Block", ylabel="Correlation Time / ns", xlim=xlim
+    )
+    ax.xaxis.set_major_locator(MaxNLocator(integer=True))
+    ax.xaxis.set_tick_params(which="minor", bottom=False, top=False)
+    legend = ax.legend(
+        title=(
+            legend_title_base
+            + "\n"
+            + r"Mean:      ${:.4f}$ ns".format(lifetime_av)
+            + "\n"
+            + r"Std. Err.: ${:.4f}$ ns".format(lifetime_se)
+        ),
+        loc="best",
+        **mdtplt.LEGEND_KWARGS_XSMALL,
+    )
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile_pdf))
+
+
+print("Creating output file(s)...")
+header = (
+    "Coordination correlation times for each trajectory block.\n"
+    + "\n"
+    + "Average coordination correlation times are calculated by numerical\n"
+    + "integration of the lifetime autocorrelation function.\n"
+    + "\n"
+    + "No. of       blocks:   {:d}\n".format(n_blocks)
+    + "No. of valid blocks:   {:d}\n".format(n_lifetime_measurements)
+    + "Mean correlation time: {:.9e} ns\n".format(lifetime_av)
+    + "Standard error:        {:.9e} ns\n".format(lifetime_se)
+    + "\n"
+    + "Corr. time from average ACF: {:9e} ns\n".format(lifetime_acf_av)
+    + "Corr. time from full    ACF: {:9e} ns\n".format(lifetime_total)
+    + "\n"
+    + "The columns contain:\n"
+    + " 1 Block number\n"
+    + " 2 Block start / ns\n"
+    + " 3 Block end / ns\n"
+    + " 4 {:s} correlation time / ns\n".format(args.cmp)
+)
+data = np.column_stack(
+    [np.arange(1, n_blocks + 1), blocks[:-1], blocks[1:], lifetimes]
+)
+leap.io_handler.savetxt(outfile_txt, data, header=header)
+print("Created {}".format(outfile_txt))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/renewal_events_bulk/plot_lifetime_autocorr_block_av_and_renewal_times_chain-length_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events_bulk/plot_lifetime_autocorr_block_av_and_renewal_times_chain-length_dependence.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the block averaged coordination correlation times and the renewal
+times as function of the PEO chain length in one plot.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import MaxNLocator
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the block averaged coordination correlation times and the"
+        " renewal times as function of the PEO chain length in one plot."
+    )
+)
+args = parser.parse_args()
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+prefix = settings + "_lintf2_peoN_20-1_sc80_"
+infile_renew_peo = prefix + "renewal_times_Li-ether_continuous.txt.gz"
+# infile_renew_tfsi = prefix + "renewal_times_Li-NTf2_continuous.txt.gz"
+outfile = prefix + "lifetime_autocorr_block_average_and_renewal_times.pdf"
+
+cmps = ("Li-OE", "Li-OBT", "Li-ether", "Li-NTf2")
+analysis = "lifetime_autocorr"  # Analysis name.
+analysis_dir = analysis + "_block_average"
+tool = "mdt"  # Analysis software.
+
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_[gp]*[0-9]*_20-1_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, path_key="bulk", sort_key="O_per_chain"
+)
+
+
+print("Reading data...")
+# Renewal times.
+rnw_peo_data = np.loadtxt(infile_renew_peo, usecols=(0, 29))
+# rnw_tfsi_data = np.loadtxt(infile_renew_tfsi, usecols=(0, 29))
+
+# Correlation times.
+acf_data = np.full((3, len(cmps), Sims.n_sims), np.nan, dtype=np.float32)
+for cmp_ix, cmp in enumerate(cmps):
+    analysis_suffix = "_" + cmp  # Analysis name specification.
+    ana_path = os.path.join(analysis_dir, analysis + analysis_suffix)
+    file_suffix = analysis_dir + analysis_suffix + ".txt.gz"
+    infiles = leap.simulation.get_ana_files(Sims, ana_path, tool, file_suffix)
+    for sim_ix, infile in enumerate(infiles):
+        lifetimes = np.loadtxt(infile, usecols=(3,))
+        n_lifetime_measurements = np.count_nonzero(np.isfinite(lifetimes))
+        if n_lifetime_measurements == 1:
+            lifetime_av = lifetimes[np.isfinite(lifetimes)][0]
+            lifetime_se = np.nan
+        elif n_lifetime_measurements > 1:
+            lifetime_av = np.nanmean(lifetimes)
+            lifetime_se = np.nanstd(lifetimes, ddof=1) / np.sqrt(
+                n_lifetime_measurements
+            )
+        else:
+            lifetime_av, lifetime_se = np.nan, np.nan
+        # Mean
+        acf_data[0][cmp_ix][sim_ix] = lifetime_av
+        # Standard error
+        acf_data[1][cmp_ix][sim_ix] = lifetime_se
+        # Number of n_lifetime_measurements
+        acf_data[2][cmp_ix][sim_ix] = n_lifetime_measurements
+    del lifetimes, n_lifetime_measurements, lifetime_av, lifetime_se
+
+print("Creating plot(s)...")
+xlabel = r"Ether Oxygens per Chain $n_{EO}$"
+xlim = (1, 200)
+legend_title = r"$r = 0.05$"
+labels = (
+    r"$Li-O_{PEO}$ Correlation",
+    r"$Li-O_{TFSI}$ Correlation",
+    r"$Li-PEO$ Correlation",
+    r"$Li-TFSI$ Correlation",
+    r"$Li-PEO$ Renewal",
+    # r"$Li-TFSI$ Renewal",
+)
+colors = ("tab:blue", "tab:cyan", "tab:red", "tab:orange", "tab:purple")
+markers = ("^", "v", "s", "D", "o")
+linestyles = ("solid",) * 4 + ("dashed",)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot renewal and correlation times.
+    fig, ax = plt.subplots(clear=True)
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-PEO$ Renewal"):
+            xdata, ydata = rnw_peo_data[:, 0], rnw_peo_data[:, 1]
+            yerr = None
+        # elif label.startswith(r"$Li-TFSI$ Renewal"):
+        #     xdata, ydata = rnw_tfsi_data[:, 0], rnw_tfsi_data[:, 1]
+        #     yerr = None
+        else:
+            xdata = Sims.O_per_chain
+            ydata, yerr = acf_data[0, i], acf_data[1, i]
+        # valid = np.isfinite(ydata)
+        # xdata, ydata, yerr = xdata[valid], ydata[valid], yerr[valid]
+        ax.errorbar(
+            xdata,
+            ydata,
+            yerr=yerr,
+            label=label,
+            color=colors[i],
+            marker=markers[i],
+            linestyle=linestyles[i],
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel="Time Scale / ns", xlim=xlim)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title, **mdtplt.LEGEND_KWARGS_XSMALL)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+    # Plot number of measurements.
+    fig, ax = plt.subplots(clear=True)
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-PEO$ Renewal") or label.startswith(
+            r"$Li-TFSI$ Renewal"
+        ):
+            continue
+        ax.plot(
+            Sims.O_per_chain,
+            acf_data[2, i],
+            label=label,
+            color=colors[i],
+            marker=markers[i],
+            linestyle=linestyles[i],
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+    ax.yaxis.set_tick_params(which="minor", bottom=False, top=False)
+    ax.set(
+        xlabel=xlabel,
+        ylabel="No. of Measurements",
+        xlim=xlim,
+        ylim=(-0.5, np.max(acf_data[2]) + 0.5),
+    )
+    legend = ax.legend(title=legend_title, **mdtplt.LEGEND_KWARGS_XSMALL)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot standard errors.
+    fig, ax = plt.subplots(clear=True)
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-PEO$ Renewal") or label.startswith(
+            r"$Li-TFSI$ Renewal"
+        ):
+            continue
+        else:
+            xdata = Sims.O_per_chain
+            ydata = acf_data[1, i]
+        # valid = np.isfinite(ydata)
+        # xdata, ydata, = xdata[valid], ydata[valid]
+        ax.plot(
+            xdata,
+            ydata,
+            label=label,
+            color=colors[i],
+            marker=markers[i],
+            linestyle=linestyles[i],
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel="Std. Err. of Corr. Times / ns", xlim=xlim)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title, **mdtplt.LEGEND_KWARGS_XSMALL)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+    # Compare block averaged correlation times to correlation times
+    # calculated using the full trajectory.
+    fig, ax = plt.subplots(clear=True)
+    # Block averaged correlation times.
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-PEO$ Renewal") or label.startswith(
+            r"$Li-TFSI$ Renewal"
+        ):
+            continue
+        else:
+            xdata = Sims.O_per_chain
+            ydata, yerr = acf_data[0, i], acf_data[1, i]
+        # valid = np.isfinite(ydata)
+        # xdata, ydata, yerr = xdata[valid], ydata[valid], yerr[valid]
+        ax.errorbar(
+            xdata,
+            ydata,
+            yerr=yerr,
+            label=None,
+            color=leap.plot.change_brightness(colors[i], 0.8),
+            marker=markers[i],
+            linestyle="solid",
+            alpha=leap.plot.ALPHA,
+        )
+    # Correlation times calculated from full trajectory.
+    path_to_acf = "../../lifetime_autocorr/chain-length_dependence/"
+    infile_acf = (
+        path_to_acf
+        + prefix
+        + "lifetime_autocorr_combined_Li-OE_Li-OBT_Li-ether_Li-NTf2.txt.gz"
+    )
+    acf_data = np.loadtxt(infile_acf)
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-O_{PEO}$ Correlation"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 1]
+        elif label.startswith(r"$Li-O_{TFSI}$ Correlation"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 2]
+        elif label.startswith(r"$Li-PEO$ Correlation"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 3]
+        elif label.startswith(r"$Li-TFSI$ Correlation"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 4]
+        elif label.startswith(r"$Li-PEO$ Renewal"):
+            xdata, ydata = rnw_peo_data[:, 0], rnw_peo_data[:, 1]
+        # elif label.startswith(r"$Li-TFSI$ Renewal"):
+        #     xdata, ydata = rnw_tfsi_data[:, 0], rnw_tfsi_data[:, 1]
+        else:
+            raise ValueError("Unknown 'label': '{}'".format(label))
+        valid = np.isfinite(ydata)
+        xdata, ydata = xdata[valid], ydata[valid]
+        ax.plot(
+            xdata,
+            ydata,
+            label=label,
+            color=leap.plot.change_brightness(colors[i], 1.4),
+            marker=markers[i],
+            linestyle="dashed",
+            alpha=leap.plot.ALPHA,
+        )
+    ax.plot([], [], color="black", linestyle="solid", label="Block average")
+    ax.plot([], [], color="gray", linestyle="dashed", label="Full trajectory")
+    ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+    ax.set(xlabel=xlabel, ylabel="Time Scale / ns", xlim=xlim)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title, **mdtplt.LEGEND_KWARGS_XSMALL)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")

--- a/scripts/bulk_and_walls/mdt/renewal_events_bulk/plot_lifetime_autocorr_block_av_and_renewal_times_conc_dependence.py
+++ b/scripts/bulk_and_walls/mdt/renewal_events_bulk/plot_lifetime_autocorr_block_av_and_renewal_times_conc_dependence.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+
+
+"""
+Plot the block averaged coordination correlation times and the renewal
+times as function of the salt concentration in one plot.
+"""
+
+
+# Standard libraries
+import argparse
+import os
+
+# Third-party libraries
+import matplotlib.pyplot as plt
+import mdtools as mdt
+import mdtools.plot as mdtplt  # Load MDTools plot style  # noqa: F401
+import numpy as np
+from matplotlib.backends.backend_pdf import PdfPages
+from matplotlib.ticker import MaxNLocator, MultipleLocator
+
+# First-party libraries
+import lintf2_ether_ana_postproc as leap
+
+
+def equalize_xticks(ax):
+    """
+    Equalize x-ticks so that plots can be better stacked together.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes
+        The :class:`~matplotlib.axes.Axes` for which to equalize the x
+        ticks.
+    """
+    ax.xaxis.set_major_locator(MultipleLocator(0.1))
+
+
+# Input parameters.
+parser = argparse.ArgumentParser(
+    description=(
+        "Plot the block averaged coordination correlation times and the"
+        " renewal times as function of the salt concentration in one plot."
+    )
+)
+parser.add_argument(
+    "--sol",
+    type=str,
+    required=True,
+    choices=("g1", "g4", "peo63"),
+    help="Solvent name.",
+)
+args = parser.parse_args()
+
+settings = "pr_nvt423_nh"  # Simulation settings.
+prefix = settings + "_lintf2_" + args.sol + "_r_sc80_"
+infile_renew_peo = prefix + "renewal_times_Li-ether_continuous.txt.gz"
+# infile_renew_tfsi = prefix + "renewal_times_Li-NTf2_continuous.txt.gz"
+outfile = prefix + "lifetime_autocorr_block_average_and_renewal_times.pdf"
+
+cmps = ("Li-OE", "Li-OBT", "Li-ether", "Li-NTf2")
+analysis = "lifetime_autocorr"  # Analysis name.
+analysis_dir = analysis + "_block_average"
+tool = "mdt"  # Analysis software.
+
+
+print("Creating Simulation instance(s)...")
+sys_pat = "lintf2_" + args.sol + "_[0-9]*-[0-9]*_sc80"
+set_pat = "[0-9][0-9]_" + settings + "_" + sys_pat
+Sims = leap.simulation.get_sims(
+    sys_pat, set_pat, path_key="bulk", sort_key="Li_O_ratio"
+)
+
+
+print("Reading data...")
+# Renewal times.
+rnw_peo_data = np.loadtxt(infile_renew_peo, usecols=(0, 29))
+# rnw_tfsi_data = np.loadtxt(infile_renew_tfsi, usecols=(0, 29))
+
+# Correlation times.
+acf_data = np.full((3, len(cmps), Sims.n_sims), np.nan, dtype=np.float32)
+for cmp_ix, cmp in enumerate(cmps):
+    analysis_suffix = "_" + cmp  # Analysis name specification.
+    ana_path = os.path.join(analysis_dir, analysis + analysis_suffix)
+    file_suffix = analysis_dir + analysis_suffix + ".txt.gz"
+    infiles = leap.simulation.get_ana_files(Sims, ana_path, tool, file_suffix)
+    for sim_ix, infile in enumerate(infiles):
+        lifetimes = np.loadtxt(infile, usecols=(3,))
+        n_lifetime_measurements = np.count_nonzero(np.isfinite(lifetimes))
+        if n_lifetime_measurements == 1:
+            lifetime_av = lifetimes[np.isfinite(lifetimes)][0]
+            lifetime_se = np.nan
+        elif n_lifetime_measurements > 1:
+            lifetime_av = np.nanmean(lifetimes)
+            lifetime_se = np.nanstd(lifetimes, ddof=1) / np.sqrt(
+                n_lifetime_measurements
+            )
+        else:
+            lifetime_av, lifetime_se = np.nan, np.nan
+        # Mean
+        acf_data[0][cmp_ix][sim_ix] = lifetime_av
+        # Standard error
+        acf_data[1][cmp_ix][sim_ix] = lifetime_se
+        # Number of n_lifetime_measurements
+        acf_data[2][cmp_ix][sim_ix] = n_lifetime_measurements
+    del lifetimes, n_lifetime_measurements, lifetime_av, lifetime_se
+
+print("Creating plot(s)...")
+xlabel = r"Li-to-EO Ratio $r$"
+xlim = (0, 0.4 + 0.0125)
+if args.sol == "g1":
+    legend_title = r"$n_{EO} = 2$"
+elif args.sol == "g4":
+    legend_title = r"$n_{EO} = 5$"
+elif args.sol == "peo63":
+    legend_title = r"$n_{EO} = 64$"
+else:
+    raise ValueError("Unknown --sol: {}".format(args.sol))
+labels = (
+    r"$Li-O_{PEO}$ Correlation",
+    r"$Li-O_{TFSI}$ Correlation",
+    r"$Li-PEO$ Correlation",
+    r"$Li-TFSI$ Correlation",
+    r"$Li-PEO$ Renewal",
+    # r"$Li-TFSI$ Renewal",
+)
+colors = ("tab:blue", "tab:cyan", "tab:red", "tab:orange", "tab:purple")
+markers = ("^", "v", "s", "D", "o")
+linestyles = ("solid",) * 4 + ("dashed",)
+
+mdt.fh.backup(outfile)
+with PdfPages(outfile) as pdf:
+    # Plot renewal and correlation times.
+    fig, ax = plt.subplots(clear=True)
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-PEO$ Renewal"):
+            xdata, ydata = rnw_peo_data[:, 0], rnw_peo_data[:, 1]
+            yerr = None
+        # elif label.startswith(r"$Li-TFSI$ Renewal"):
+        #     xdata, ydata = rnw_tfsi_data[:, 0], rnw_tfsi_data[:, 1]
+        #     yerr = None
+        else:
+            xdata = Sims.Li_O_ratios
+            ydata, yerr = acf_data[0, i], acf_data[1, i]
+        # valid = np.isfinite(ydata)
+        # xdata, ydata, yerr = xdata[valid], ydata[valid], yerr[valid]
+        ax.errorbar(
+            xdata,
+            ydata,
+            yerr=yerr,
+            label=label,
+            color=colors[i],
+            marker=markers[i],
+            linestyle=linestyles[i],
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set(xlabel=xlabel, ylabel="Time Scale / ns", xlim=xlim)
+    equalize_xticks(ax)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title, **mdtplt.LEGEND_KWARGS_XSMALL)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+    # Plot number of measurements.
+    fig, ax = plt.subplots(clear=True)
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-PEO$ Renewal") or label.startswith(
+            r"$Li-TFSI$ Renewal"
+        ):
+            continue
+        ax.plot(
+            Sims.Li_O_ratios,
+            acf_data[2, i],
+            label=label,
+            color=colors[i],
+            marker=markers[i],
+            linestyle=linestyles[i],
+            alpha=leap.plot.ALPHA,
+        )
+    ax.yaxis.set_major_locator(MaxNLocator(integer=True))
+    ax.yaxis.set_tick_params(which="minor", bottom=False, top=False)
+    ax.set(
+        xlabel=xlabel,
+        ylabel="No. of Measurements",
+        xlim=xlim,
+        ylim=(-0.5, np.max(acf_data[2]) + 0.5),
+    )
+    equalize_xticks(ax)
+    legend = ax.legend(title=legend_title, **mdtplt.LEGEND_KWARGS_XSMALL)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    plt.close()
+
+    # Plot standard errors.
+    fig, ax = plt.subplots(clear=True)
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-PEO$ Renewal") or label.startswith(
+            r"$Li-TFSI$ Renewal"
+        ):
+            continue
+        else:
+            xdata = Sims.Li_O_ratios
+            ydata = acf_data[1, i]
+        # valid = np.isfinite(ydata)
+        # xdata, ydata, = xdata[valid], ydata[valid]
+        ax.plot(
+            xdata,
+            ydata,
+            label=label,
+            color=colors[i],
+            marker=markers[i],
+            linestyle=linestyles[i],
+            alpha=leap.plot.ALPHA,
+        )
+    ax.set(xlabel=xlabel, ylabel="Std. Err. of Corr. Times / ns", xlim=xlim)
+    equalize_xticks(ax)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title, **mdtplt.LEGEND_KWARGS_XSMALL)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+    # Compare block averaged correlation times to correlation times
+    # calculated using the full trajectory.
+    fig, ax = plt.subplots(clear=True)
+    # Block averaged correlation times.
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-PEO$ Renewal") or label.startswith(
+            r"$Li-TFSI$ Renewal"
+        ):
+            continue
+        else:
+            xdata = Sims.Li_O_ratios
+            ydata, yerr = acf_data[0, i], acf_data[1, i]
+        # valid = np.isfinite(ydata)
+        # xdata, ydata, yerr = xdata[valid], ydata[valid], yerr[valid]
+        ax.errorbar(
+            xdata,
+            ydata,
+            yerr=yerr,
+            label=None,
+            color=leap.plot.change_brightness(colors[i], 0.8),
+            marker=markers[i],
+            linestyle="solid",
+            alpha=leap.plot.ALPHA,
+        )
+    # Correlation times calculated from full trajectory.
+    path_to_acf = "../../lifetime_autocorr/conc_dependence/"
+    infile_acf = (
+        path_to_acf
+        + prefix
+        + "lifetime_autocorr_combined_Li-OE_Li-OBT_Li-ether_Li-NTf2.txt.gz"
+    )
+    acf_data = np.loadtxt(infile_acf)
+    for i, label in enumerate(labels):
+        if label.startswith(r"$Li-O_{PEO}$ Correlation"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 1]
+        elif label.startswith(r"$Li-O_{TFSI}$ Correlation"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 2]
+        elif label.startswith(r"$Li-PEO$ Correlation"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 3]
+        elif label.startswith(r"$Li-TFSI$ Correlation"):
+            xdata, ydata = acf_data[:, 0], acf_data[:, 4]
+        elif label.startswith(r"$Li-PEO$ Renewal"):
+            xdata, ydata = rnw_peo_data[:, 0], rnw_peo_data[:, 1]
+        # elif label.startswith(r"$Li-TFSI$ Renewal"):
+        #     xdata, ydata = rnw_tfsi_data[:, 0], rnw_tfsi_data[:, 1]
+        else:
+            raise ValueError("Unknown 'label': '{}'".format(label))
+        valid = np.isfinite(ydata)
+        xdata, ydata = xdata[valid], ydata[valid]
+        ax.plot(
+            xdata,
+            ydata,
+            label=label,
+            color=leap.plot.change_brightness(colors[i], 1.4),
+            marker=markers[i],
+            linestyle="dashed",
+            alpha=leap.plot.ALPHA,
+        )
+    ax.plot([], [], color="black", linestyle="solid", label="Block average")
+    ax.plot([], [], color="gray", linestyle="dashed", label="Full trajectory")
+    ax.set(xlabel=xlabel, ylabel="Time Scale / ns", xlim=xlim)
+    equalize_xticks(ax)
+    ylim = ax.get_ylim()
+    if ylim[0] < 0:
+        ax.set_ylim(0, ylim[1])
+    legend = ax.legend(title=legend_title, **mdtplt.LEGEND_KWARGS_XSMALL)
+    legend.get_title().set_multialignment("center")
+    pdf.savefig()
+    yd_min, yd_max = leap.plot.get_ydata_min_max(ax)
+    if np.any(np.greater(yd_min, 0)):
+        # Log scale y.
+        ax.relim()
+        ax.autoscale()
+        ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+        ax.set_xlim(xlim)
+        pdf.savefig()
+    plt.close()
+
+print("Created {}".format(outfile))
+print("Done")


### PR DESCRIPTION
# Scripts to plot block averaged coordination numbers and correlation times

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our contributing guidelines at
https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=0
-->

## Type of Change

* [ ] Bug fix.
* [x] New feature.
* [x] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed Changes

<!-- Give a concise summary of the most important changes. -->

* `plot_contact_hist_block_av_chain-length_dependence.py` and `plot_contact_hist_block_av_conc_dependence.py`: Create scripts to plot the block averaged contact histograms and average coordination numbers for two given compounds as function of the PEO chain length or the salt concentration.
* `plot_contact_hist_chain-length_dependence.py` and `plot_contact_hist_conc_dependence.py`: Improve code.
* `plot_lifetime_autocorr_block_av.py`: Create a script to plot the lifetime autocorrelation function for two given compounds as function of the trajectory blocks used for block averaging.
* `plot_lifetime_autocorr_block_av_and_renewal_times_chain-length_dependence.py` and `plot_lifetime_autocorr_block_av_and_renewal_times_conc_dependence.py`: Create scripts to plot the block averaged coordination correlation times and the renewal times as function of the PEO chain length or as function of the salt concentration in one plot.

## PR Checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the [contributing guidelines](https://github.com/andthum/lintf2_ether_ana_postproc/blob/main/CONTRIBUTING.rst).
* [ ] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] The CI workflow is passing.
